### PR TITLE
ログに出力後、例外を出すように

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.1.7"
+version = "0.1.8"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/output/sf_bulk_api/ForceClient.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/ForceClient.java
@@ -72,6 +72,7 @@ public class ForceClient
         }
         catch (Exception e) {
             logger.error(e.getMessage(), e);
+            throw new RuntimeException("Salesforce throw exception", e);
         }
     }
 
@@ -91,6 +92,7 @@ public class ForceClient
         }
         catch (Exception e) {
             logger.error(e.getMessage(), e);
+            throw new RuntimeException("Salesforce throw exception", e);
         }
     }
 
@@ -102,6 +104,7 @@ public class ForceClient
         }
         catch (Exception e) {
             logger.error(e.getMessage(), e);
+            throw new RuntimeException("Salesforce throw exception", e);
         }
     }
 


### PR DESCRIPTION
before
エラーが起きてもembulkの処理が最後まで走って正常に終了していた。
```
2022-01-31 10:21:28.899 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2022-01-31 10:21:30.132 +0000 [INFO] (embulk-output-executor-0): sObjects size:4
2022-01-31 10:21:30.292 +0000 [ERROR] (embulk-output-executor-0): null
com.sforce.soap.partner.fault.InvalidSObjectFault: null
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_282]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:1.8.0_282]
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:1.8.0_282]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[na:1.8.0_282]
        at java.lang.Class.newInstance(Class.java:442) ~[na:1.8.0_282]
        at com.sforce.ws.bind.TypeMapper.readSingle(TypeMapper.java:677) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.ws.bind.TypeMapper.readObject(TypeMapper.java:560) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.ws.transport.SoapConnection.parseDetail(SoapConnection.java:250) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.ws.transport.SoapConnection.createException(SoapConnection.java:224) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.ws.transport.SoapConnection.receive(SoapConnection.java:163) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.ws.transport.SoapConnection.send(SoapConnection.java:108) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.soap.partner.PartnerConnection.create(PartnerConnection.java:1608) ~[force-partner-api-47.0.0.jar:na]
        at org.embulk.output.sf_bulk_api.ForceClient.insert(ForceClient.java:70) [embulk-output-sf_bulk_api-0.1.7-0.1.8.jar:na]
        at org.embulk.output.sf_bulk_api.ForceClient.action(ForceClient.java:41) [embulk-output-sf_bulk_api-0.1.7-0.1.8.jar:na]
        at org.embulk.output.sf_bulk_api.SForceTransactionalPageOutput.add(SForceTransactionalPageOutput.java:55) [embulk-output-sf_bulk_api-0.1.7-0.1.8.jar:na]
        at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput$OutputWorker.call(LocalExecutorPlugin.java:351) [embulk:0.9.25]
        at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput$OutputWorker.call(LocalExecutorPlugin.java:291) [embulk:0.9.25]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_282]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_282]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_282]
        at java.lang.Thread.run(Thread.java:748) [na:1.8.0_282]
2022-01-31 10:21:30.820 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
2022-01-31 10:21:30.843 +0000 [INFO] (main): Committed.
2022-01-31 10:21:30.844 +0000 [INFO] (main): Next config diff: {"in":{"last_path":"test.csv"},"out":{}}
```

after
エラーの場合例外を発生させるように。
```
2022-01-31 10:18:42.854 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2022-01-31 10:18:44.454 +0000 [INFO] (embulk-output-executor-0): sObjects size:4
2022-01-31 10:18:44.624 +0000 [ERROR] (embulk-output-executor-0): null
com.sforce.soap.partner.fault.InvalidSObjectFault: null
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_282]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:1.8.0_282]
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:1.8.0_282]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[na:1.8.0_282]
        at java.lang.Class.newInstance(Class.java:442) ~[na:1.8.0_282]
        at com.sforce.ws.bind.TypeMapper.readSingle(TypeMapper.java:677) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.ws.bind.TypeMapper.readObject(TypeMapper.java:560) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.ws.transport.SoapConnection.parseDetail(SoapConnection.java:250) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.ws.transport.SoapConnection.createException(SoapConnection.java:224) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.ws.transport.SoapConnection.receive(SoapConnection.java:163) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.ws.transport.SoapConnection.send(SoapConnection.java:108) ~[force-wsc-47.0.0.jar:na]
        at com.sforce.soap.partner.PartnerConnection.create(PartnerConnection.java:1608) ~[force-partner-api-47.0.0.jar:na]
        at org.embulk.output.sf_bulk_api.ForceClient.insert(ForceClient.java:70) [embulk-output-sf_bulk_api-0.1.7-0.1.8.jar:na]
        at org.embulk.output.sf_bulk_api.ForceClient.action(ForceClient.java:41) [embulk-output-sf_bulk_api-0.1.7-0.1.8.jar:na]
        at org.embulk.output.sf_bulk_api.SForceTransactionalPageOutput.add(SForceTransactionalPageOutput.java:55) [embulk-output-sf_bulk_api-0.1.7-0.1.8.jar:na]
        at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput$OutputWorker.call(LocalExecutorPlugin.java:351) [embulk:0.9.25]
        at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput$OutputWorker.call(LocalExecutorPlugin.java:291) [embulk:0.9.25]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_282]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_282]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_282]
        at java.lang.Thread.run(Thread.java:748) [na:1.8.0_282]
2022-01-31 10:18:45.186 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
org.embulk.exec.PartialExecutionException: java.lang.RuntimeException: Salesforce throw exception
        at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:340)
        at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:566)
        at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:35)
        at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:353)
        at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:350)
        at org.embulk.spi.Exec.doWith(Exec.java:22)
        at org.embulk.exec.BulkLoader.run(BulkLoader.java:350)
        at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:242)
        at org.embulk.EmbulkRunner.runInternal(EmbulkRunner.java:291)
        at org.embulk.EmbulkRunner.run(EmbulkRunner.java:155)
        at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:431)
        at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:90)
        at org.embulk.cli.Main.main(Main.java:64)
Caused by: java.lang.RuntimeException: Salesforce throw exception
        at org.embulk.output.sf_bulk_api.ForceClient.insert(ForceClient.java:75)
        at org.embulk.output.sf_bulk_api.ForceClient.action(ForceClient.java:41)
        at org.embulk.output.sf_bulk_api.SForceTransactionalPageOutput.add(SForceTransactionalPageOutput.java:55)
        at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput$OutputWorker.call(LocalExecutorPlugin.java:351)
        at org.embulk.exec.LocalExecutorPlugin$ScatterTransactionalPageOutput$OutputWorker.call(LocalExecutorPlugin.java:291)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: [InvalidSObjectFault [ApiQueryFault [ApiFault  exceptionCode='INVALID_TYPE'
 exceptionMessage='sObject type 'string' is not supported. If you are attempting to use a custom object, be sure to append the '__c' after the entity name. Please reference your WSDL or the describe call for the appropriate names.'
 extendedErrorDetails='{[0]}'
]
 row='-1'
 column='-1'
]
]

        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at java.lang.Class.newInstance(Class.java:442)
        at com.sforce.ws.bind.TypeMapper.readSingle(TypeMapper.java:677)
        at com.sforce.ws.bind.TypeMapper.readObject(TypeMapper.java:560)
        at com.sforce.ws.transport.SoapConnection.parseDetail(SoapConnection.java:250)
        at com.sforce.ws.transport.SoapConnection.createException(SoapConnection.java:224)
        at com.sforce.ws.transport.SoapConnection.receive(SoapConnection.java:163)
        at com.sforce.ws.transport.SoapConnection.send(SoapConnection.java:108)
        at com.sforce.soap.partner.PartnerConnection.create(PartnerConnection.java:1608)
        at org.embulk.output.sf_bulk_api.ForceClient.insert(ForceClient.java:70)
        ... 8 more

Error: java.lang.RuntimeException: Salesforce throw exception
```