### PR TITLE
salesforce例外時のログを出力する

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.1.7"
+version = "0.1.8"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/output/sf_bulk_api/ForceClient.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/ForceClient.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import com.sforce.soap.partner.PartnerConnection;
 import com.sforce.soap.partner.Connector;
+import com.sforce.soap.partner.fault.ApiFault;
 import com.sforce.soap.partner.sobject.SObject;
 import com.sforce.soap.partner.SaveResult;
 import com.sforce.soap.partner.UpsertResult;
@@ -70,7 +71,9 @@ public class ForceClient
             final SaveResult[] saveResultArray = partnerConnection.create(sObjects.toArray(new SObject[sObjects.size()]));
             loggingSaveErrorMessage(saveResultArray);
         }
-        catch (Exception e) {
+        catch (ApiFault e) {
+            logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
+        } catch (Exception e) {
             logger.error(e.getMessage(), e);
         }
     }
@@ -89,7 +92,9 @@ public class ForceClient
                 }
             });
         }
-        catch (Exception e) {
+        catch (ApiFault e) {
+            logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
+        } catch (Exception e) {
             logger.error(e.getMessage(), e);
         }
     }
@@ -100,7 +105,9 @@ public class ForceClient
             final SaveResult[] saveResultArray = partnerConnection.update(sObjects.toArray(new SObject[sObjects.size()]));
             loggingSaveErrorMessage(saveResultArray);
         }
-        catch (Exception e) {
+        catch (ApiFault e) {
+            logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
+        } catch (Exception e) {
             logger.error(e.getMessage(), e);
         }
     }

--- a/src/main/java/org/embulk/output/sf_bulk_api/ForceClient.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/ForceClient.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 
 import com.sforce.soap.partner.PartnerConnection;
 import com.sforce.soap.partner.Connector;
-import com.sforce.soap.partner.fault.ApiFault;
 import com.sforce.soap.partner.sobject.SObject;
 import com.sforce.soap.partner.SaveResult;
 import com.sforce.soap.partner.UpsertResult;
@@ -65,51 +64,27 @@ public class ForceClient
         return config;
     }
 
-    private void insert(final List<SObject> sObjects)
-    {
-        try {
-            final SaveResult[] saveResultArray = partnerConnection.create(sObjects.toArray(new SObject[sObjects.size()]));
-            loggingSaveErrorMessage(saveResultArray);
-        }
-        catch (ApiFault e) {
-            logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
+    private void insert(final List<SObject> sObjects) throws ConnectionException {
+        final SaveResult[] saveResultArray = partnerConnection.create(sObjects.toArray(new SObject[sObjects.size()]));
+        loggingSaveErrorMessage(saveResultArray);
     }
 
-    private void upsert(final String key, final List<SObject> sObjects)
-    {
-        try {
-            final UpsertResult[] upsertResultArray = partnerConnection.upsert(key, sObjects.toArray(new SObject[sObjects.size()]));
-            final List<UpsertResult> upsertResults = Arrays.asList(upsertResultArray);
-            upsertResults.forEach(result -> {
-                if (!result.isSuccess()) {
-                    final List<String> errors = Arrays.asList(result.getErrors())
-                                                .stream().map(e -> e.getStatusCode() + ":" + e.getMessage())
-                                                .collect(Collectors.toList());
-                    logger.warn(String.join(",", errors));
-                }
-            });
-        }
-        catch (ApiFault e) {
-            logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
+    private void upsert(final String key, final List<SObject> sObjects) throws ConnectionException {
+        final UpsertResult[] upsertResultArray = partnerConnection.upsert(key, sObjects.toArray(new SObject[sObjects.size()]));
+        final List<UpsertResult> upsertResults = Arrays.asList(upsertResultArray);
+        upsertResults.forEach(result -> {
+            if (!result.isSuccess()) {
+                final List<String> errors = Arrays.asList(result.getErrors())
+                                            .stream().map(e -> e.getStatusCode() + ":" + e.getMessage())
+                                            .collect(Collectors.toList());
+                logger.warn(String.join(",", errors));
+            }
+        });
     }
 
-    private void update(final List<SObject> sObjects)
-    {
-        try {
-            final SaveResult[] saveResultArray = partnerConnection.update(sObjects.toArray(new SObject[sObjects.size()]));
-            loggingSaveErrorMessage(saveResultArray);
-        }
-        catch (ApiFault e) {
-            logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
+    private void update(final List<SObject> sObjects) throws ConnectionException {
+        final SaveResult[] saveResultArray = partnerConnection.update(sObjects.toArray(new SObject[sObjects.size()]));
+        loggingSaveErrorMessage(saveResultArray);
     }
 
     private void loggingSaveErrorMessage(final SaveResult[] saveResultArray)

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -3,6 +3,7 @@ package org.embulk.output.sf_bulk_api;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.sforce.soap.partner.fault.ApiFault;
 import com.sforce.soap.partner.sobject.SObject;
 import com.sforce.ws.ConnectionException;
 
@@ -54,7 +55,10 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput
                 forceClient.action(records);
             }
         }
-        catch (ConnectionException e) {
+        catch (ApiFault e) {
+            logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
+        }
+        catch (Exception e) {
             logger.error(e.getMessage(), e);
         }
     }


### PR DESCRIPTION
## 概要
現在、salesforce側で例外が発生した場合にログがnullで出力されている。
エラー内容がログに出力されるようにする。

例: InvalidFieldFaultのエラーログ
```
2022-02-24 08:23:15.270 +0000 [INFO] (embulk-output-executor-0): sObjects size:4
2022-02-24 08:23:15.446 +0000 [ERROR] (embulk-output-executor-0): null
com.sforce.soap.partner.fault.InvalidFieldFault: null
```

## 原因
以下のように例外をキャッチしてログを出力しているが、e.getMessage()がnullになるよう。
```java
 private void update(final List<SObject> sObjects)
    {
        try {
            final SaveResult[] saveResultArray = partnerConnection.update(sObjects.toArray(new SObject[sObjects.size()]));
            loggingSaveErrorMessage(saveResultArray);
        }
        catch (Exception e) {
            logger.error(e.getMessage(), e);
        }
    }
```

## 対応
InvalidFieldFaultやUnexpectedErrorFaultなど、以下の障害はすべて`com.sforce.soap.partner.fault.ApiFault`を継承している。
https://developer.salesforce.com/docs/atlas.ja-jp.api.meta/api/sforce_api_calls_concepts_core_data_objects.htm#i1421571

https://javadoc.io/doc/com.force.api/force-partner-api/latest/com/sforce/soap/partner/fault/package-summary.html

なので、ApiFaultをキャッチして`getExceptionMessage()`でエラー内容を取得することでログに出力されるようにした。

```
2022-02-24 09:26:32.898 +0000 [INFO] (embulk-output-executor-0): sObjects size:4
2022-02-24 09:26:33.512 +0000 [ERROR] (embulk-output-executor-0): INVALID_FIELD:No such column 'id2' on entity 'Case'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names.
com.sforce.soap.partner.fault.InvalidFieldFault: null
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_282]
```