### PR TITLE
fix records scope & error handling

### DIFF
--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -45,12 +45,7 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput
                 pageReader.getSchema().visitColumns(new SForceColumnVisitor(record, pageReader));
                 records.add(record);
                 if (records.size() >= BATCH_SIZE) {
-                    try {
-                        forceClient.action(records);
-                    } catch (ApiFault e) {
-                        // even if some records failed to register, processing continues.
-                        logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
-                    }
+                    forceClient.action(records);
                     records = new ArrayList<>();
                 }
             }
@@ -58,6 +53,9 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput
             if (CollectionUtils.isNotEmpty(records)) {
                 forceClient.action(records);
             }
+        }
+        catch (ApiFault e) {
+            logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
         }
         catch (Exception e) {
             logger.error(e.getMessage(), e);

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -23,7 +23,6 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput
     private final ForceClient forceClient;
     private final PageReader pageReader;
     private final PluginTask pluginTask;
-    private List<SObject> records;
 
     private final Logger logger =  LoggerFactory.getLogger(SForceTransactionalPageOutput.class);
 
@@ -32,22 +31,22 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput
         this.forceClient = forceClient;
         this.pageReader = pageReader;
         this.pluginTask = pluginTask;
-        this.records = new ArrayList<>();
     }
 
     @Override
     public void add(Page page)
     {
         try {
+            ArrayList records = new ArrayList<>();
             pageReader.setPage(page);
             while (pageReader.nextRecord()) {
                 final SObject record = new SObject();
                 record.setType(this.pluginTask.getObject());
                 pageReader.getSchema().visitColumns(new SForceColumnVisitor(record, pageReader));
-                this.records.add(record);
-                if (this.records.size() >= BATCH_SIZE) {
+                records.add(record);
+                if (records.size() >= BATCH_SIZE) {
                     forceClient.action(records);
-                    this.records = new ArrayList<>();
+                    records = new ArrayList<>();
                 }
             }
 

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -45,7 +45,12 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput
                 pageReader.getSchema().visitColumns(new SForceColumnVisitor(record, pageReader));
                 records.add(record);
                 if (records.size() >= BATCH_SIZE) {
-                    forceClient.action(records);
+                    try {
+                        forceClient.action(records);
+                    } catch (ApiFault e) {
+                        // even if some records failed to register, processing continues.
+                        logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
+                    }
                     records = new ArrayList<>();
                 }
             }
@@ -53,9 +58,6 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput
             if (CollectionUtils.isNotEmpty(records)) {
                 forceClient.action(records);
             }
-        }
-        catch (ApiFault e) {
-            logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
         }
         catch (Exception e) {
             logger.error(e.getMessage(), e);


### PR DESCRIPTION
- fixed `records` scope
    - `records` is not initialized when exception occurred, thus `records` size exceeds 200 and an `EXCEEDED_ID_LIMIT` error occurs.
- fixed `ApiFault` handling