### PR TITLE
Improve error handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -1,32 +1,40 @@
-# Sf Bulk Api file output plugin for Embulk
+# embulk-output-sf_bulk_api
 
-TODO: Write short description here and build.gradle file.
+Embulk output plugin for Salesforce Bulk API.
 
 ## Overview
 
-* **Plugin type**: file output
+* **Plugin type**: output
 * **Load all or nothing**: no
 * **Resume supported**: no
-* **Cleanup supported**: yes
 
 ## Configuration
 
-- **option1**: description (integer, required)
-- **option2**: description (string, default: `"myvalue"`)
-- **option3**: description (string, default: `null`)
+- **username**: Login username (string, required)
+- **password**: Login password (string, required)
+- **security_token**: User’s security token (string, required)
+- **auth_end_point**: SOAP API authentication endpoint (string, default: `https://login.salesforce.com/services/Soap/u/`)
+- **api_version**: SOAP API version (string, default: `46.0`)
+- **object**: Salesforce object (sObject) type (string, required)
+- **action_type**: Action type (`insert`, `update`, or `upsert`, required)
+- **upsert_key**: Name of the external ID field (string, required when `upsert` action, default: `key`)
+- **throw_if_failed**: Whether to throw exception at the end of transaction if there are one or more failures (boolean, default: `true`)
 
 ## Example
 
 ```yaml
 out:
   type: sf_bulk_api
-  option1: example1
-  option2: example2
+  username: username
+  password: password
+  security_token: security_token
+  object: ExampleCustomObject__c
+  action_type: upsert
+  upsert_key: Name
 ```
-
 
 ## Build
 
 ```
-$ ./gradlew gem  # -t to watch change of files and rebuild continuously
+$ ./gradlew gem
 ```

--- a/src/main/java/org/embulk/output/sf_bulk_api/AbortException.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/AbortException.java
@@ -1,0 +1,7 @@
+package org.embulk.output.sf_bulk_api;
+
+public class AbortException extends RuntimeException {
+  public AbortException(final Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/org/embulk/output/sf_bulk_api/ErrorHandler.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/ErrorHandler.java
@@ -1,0 +1,151 @@
+package org.embulk.output.sf_bulk_api;
+
+import com.google.gson.Gson;
+import com.sforce.soap.partner.IError;
+import com.sforce.soap.partner.SaveResult;
+import com.sforce.soap.partner.UpsertResult;
+import com.sforce.soap.partner.fault.ApiFault;
+import com.sforce.soap.partner.fault.ExceptionCode;
+import com.sforce.soap.partner.sobject.SObject;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.embulk.spi.Column;
+import org.embulk.spi.Schema;
+import org.embulk.spi.time.Timestamp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ErrorHandler {
+  private static final List<ExceptionCode> ABORT_EXCEPTION_CODES =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              ExceptionCode.INVALID_SESSION_ID,
+              ExceptionCode.INVALID_OPERATION_WITH_EXPIRED_PASSWORD));
+  private static final Gson GSON = new Gson();
+
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final Schema schema;
+
+  public ErrorHandler(final Schema schema) {
+    this.schema = schema;
+  }
+
+  public long handleFault(final List<SObject> sObjects, final ApiFault fault) {
+    if (ABORT_EXCEPTION_CODES.contains(fault.getExceptionCode())) {
+      throw new AbortException(fault); // Abort immediately
+    }
+    final String exception =
+        String.format("%s(%s)", fault.getExceptionCode(), fault.getExceptionMessage());
+    sObjects.forEach(sObject -> log(sObject, exception));
+    return sObjects.size();
+  }
+
+  private void log(final SObject sObject, final String exception) {
+    logger.warn(String.format("object:%s,exception:%s", getObject(sObject), exception));
+  }
+
+  public long handleErrors(final List<SObject> sObjects, final SaveResult[] results) {
+    return handleErrors(
+        sObjects,
+        Arrays.stream(results)
+            .map(
+                result ->
+                    new Result() {
+                      @Override
+                      public boolean isFailure() {
+                        return !result.isSuccess();
+                      }
+
+                      @Override
+                      public IError[] getErrors() {
+                        return result.getErrors();
+                      }
+                    })
+            .collect(Collectors.toList()));
+  }
+
+  public long handleErrors(final List<SObject> sObjects, final UpsertResult[] results) {
+    return handleErrors(
+        sObjects,
+        Arrays.stream(results)
+            .map(
+                result ->
+                    new Result() {
+                      @Override
+                      public boolean isFailure() {
+                        return !result.isSuccess();
+                      }
+
+                      @Override
+                      public IError[] getErrors() {
+                        return result.getErrors();
+                      }
+                    })
+            .collect(Collectors.toList()));
+  }
+
+  private long handleErrors(final List<SObject> sObjects, final List<Result> results) {
+    if (sObjects.size() != results.size()) {
+      throw new IllegalArgumentException(
+          String.format("%d != %d", sObjects.size(), results.size()));
+    }
+    IntStream.range(0, sObjects.size())
+        .forEach(index -> log(sObjects.get(index), results.get(index)));
+    return results.stream().filter(Result::isFailure).count();
+  }
+
+  private void log(final SObject sObject, final Result result) {
+    if (!result.isFailure()) {
+      return;
+    }
+    logger.warn(String.format("object:%s,errors:%s", getObject(sObject), getErrors(result)));
+  }
+
+  private String getObject(final SObject sObject) {
+    final Map<String, Object> map = new LinkedHashMap<>();
+    schema.getColumns().forEach(column -> map.put(column.getName(), getField(sObject, column)));
+    return GSON.toJson(map);
+  }
+
+  private Object getField(final SObject sObject, final Column column) {
+    final Object field = sObject.getField(column.getName());
+    if (field == null) {
+      return null;
+    }
+    final String type = column.getType().getName();
+    if ("timestamp".equals(type)) {
+      return Timestamp.ofInstant(((Calendar) field).toInstant()).toString();
+    } else if ("boolean".equals(type)) {
+      return Boolean.valueOf(field.toString());
+    } else if ("double".equals(type)) {
+      return Double.valueOf(field.toString());
+    } else if ("long".equals(type)) {
+      return Long.valueOf(field.toString());
+    } else {
+      return field.toString();
+    }
+  }
+
+  private String getErrors(final Result result) {
+    final Map<String, Object> map = new LinkedHashMap<>();
+    Arrays.stream(result.getErrors())
+        .forEach(
+            error ->
+                map.put(
+                    String.join(",", error.getFields()),
+                    String.format("%s(%s)", error.getStatusCode(), error.getMessage())));
+    return GSON.toJson(map);
+  }
+
+  private interface Result {
+    boolean isFailure();
+
+    IError[] getErrors();
+  }
+}

--- a/src/main/java/org/embulk/output/sf_bulk_api/PluginTask.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/PluginTask.java
@@ -31,4 +31,8 @@ interface PluginTask extends Task {
   @Config("upsert_key")
   @ConfigDefault("\"key\"")
   String getUpsertKey();
+
+  @Config("throw_if_failed")
+  @ConfigDefault("\"true\"")
+  boolean getThrowIfFailed();
 }

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -1,9 +1,12 @@
 package org.embulk.output.sf_bulk_api;
 
 import com.sforce.soap.partner.fault.ApiFault;
+import com.sforce.soap.partner.fault.ExceptionCode;
+import com.sforce.soap.partner.fault.UnexpectedErrorFault;
 import com.sforce.soap.partner.sobject.SObject;
 import com.sforce.ws.ConnectionException;
 import java.util.ArrayList;
+import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.Exec;
@@ -19,20 +22,27 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
   private final ForceClient forceClient;
   private final PageReader pageReader;
   private final PluginTask pluginTask;
+  private final ErrorHandler errorHandler;
 
   private final Logger logger = LoggerFactory.getLogger(SForceTransactionalPageOutput.class);
+  private boolean failed;
+  private long failures;
 
   public SForceTransactionalPageOutput(
-      ForceClient forceClient, PageReader pageReader, PluginTask pluginTask) {
+      ForceClient forceClient,
+      PageReader pageReader,
+      PluginTask pluginTask,
+      ErrorHandler errorHandler) {
     this.forceClient = forceClient;
     this.pageReader = pageReader;
     this.pluginTask = pluginTask;
+    this.errorHandler = errorHandler;
   }
 
   @Override
   public void add(Page page) {
     try {
-      ArrayList records = new ArrayList<>();
+      List<SObject> records = new ArrayList<>();
       pageReader.setPage(page);
       while (pageReader.nextRecord()) {
         final SObject record = new SObject();
@@ -41,10 +51,12 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
         records.add(record);
         if (records.size() >= BATCH_SIZE) {
           try {
-            forceClient.action(records);
+            failures += forceClient.action(records);
+            failed = failures != 0;
           } catch (ApiFault e) {
             // even if some records failed to register, processing continues.
-            logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
+            failures += errorHandler.handleFault(records, e);
+            failed = true;
           }
           records = new ArrayList<>();
         }
@@ -52,12 +64,18 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
 
       if (CollectionUtils.isNotEmpty(records)) {
         try {
-          forceClient.action(records);
+          failures += forceClient.action(records);
+          failed = failures != 0;
         } catch (ApiFault e) {
-          logger.error(e.getExceptionCode().toString() + ":" + e.getExceptionMessage(), e);
+          failures += errorHandler.handleFault(records, e);
+          failed = true;
         }
       }
+    } catch (AbortException e) {
+      logger.error(e.getMessage(), e);
+      throw e;
     } catch (Exception e) {
+      failed = true;
       logger.error(e.getMessage(), e);
     }
   }
@@ -69,7 +87,14 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
   public void close() {
     try {
       forceClient.logout();
+    } catch (UnexpectedErrorFault e) {
+      if (ExceptionCode.INVALID_SESSION_ID.equals(e.getExceptionCode())) {
+        return; // Skip logs
+      }
+      final String message = String.format("%s(%s)", e.getExceptionCode(), e.getExceptionMessage());
+      logger.warn(message, e);
     } catch (ConnectionException e) {
+      logger.warn(e.getMessage(), e);
     }
   }
 
@@ -78,6 +103,9 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
 
   @Override
   public TaskReport commit() {
-    return Exec.newTaskReport();
+    final TaskReport taskReport = Exec.newTaskReport();
+    taskReport.set("failed", failed);
+    taskReport.set("failures", failures);
+    return taskReport;
   }
 }

--- a/src/main/java/org/embulk/output/sf_bulk_api/SfBulkApiOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SfBulkApiOutputPlugin.java
@@ -26,7 +26,9 @@ public class SfBulkApiOutputPlugin implements OutputPlugin {
     final List<TaskReport> taskReports = control.run(task.dump());
     final long failures =
         taskReports.stream().mapToLong(taskReport -> taskReport.get(long.class, "failures")).sum();
-    if (taskReports.stream().anyMatch(taskReport -> taskReport.get(boolean.class, "failed"))) {
+    final boolean failed =
+        taskReports.stream().anyMatch(taskReport -> taskReport.get(boolean.class, "failed"));
+    if (task.getThrowIfFailed() && failed) {
       throw new DataException(String.format("There are %,d failures", failures));
     }
     return Exec.newConfigDiff();


### PR DESCRIPTION
## Changes

- Added object details to log when errors occur
- Throw exception at the end of transaction if there are one or more failures as follows
  ```
  org.embulk.exec.PartialExecutionException: org.embulk.spi.DataException: There are 1,200 failures
  	at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:340)
  	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:566)
  	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:35)
  	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:353)
  	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:350)
  	at org.embulk.spi.Exec.doWith(Exec.java:22)
  	at org.embulk.exec.BulkLoader.run(BulkLoader.java:350)
  	at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:242)
  	at org.embulk.EmbulkRunner.runInternal(EmbulkRunner.java:290)
  	at org.embulk.EmbulkRunner.run(EmbulkRunner.java:155)
  	at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:431)
  	at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:90)
  	at org.embulk.cli.Main.main(Main.java:64)
  Caused by: org.embulk.spi.DataException: There are 1,200 failures
  	at org.embulk.output.sf_bulk_api.SfBulkApiOutputPlugin.transaction(SfBulkApiOutputPlugin.java:30)
  	at org.embulk.exec.BulkLoader$4$1$1.transaction(BulkLoader.java:521)
  	at org.embulk.exec.LocalExecutorPlugin.transaction(LocalExecutorPlugin.java:50)
  	at org.embulk.exec.BulkLoader$4$1.run(BulkLoader.java:516)
  	at org.embulk.spi.util.Filters$RecursiveControl.transaction(Filters.java:84)
  	at org.embulk.spi.util.Filters$RecursiveControl$1.run(Filters.java:80)
  	at org.embulk.standards.RemoveColumnsFilterPlugin.transaction(RemoveColumnsFilterPlugin.java:96)
  	at org.embulk.spi.util.Filters$RecursiveControl.transaction(Filters.java:76)
  	at org.embulk.spi.util.Filters.transaction(Filters.java:42)
  	at org.embulk.exec.BulkLoader$4.run(BulkLoader.java:511)
  	at org.embulk.spi.FileInputRunner$RunnerControl$1$1.run(FileInputRunner.java:112)
  	at org.embulk.standards.CsvParserPlugin.transaction(CsvParserPlugin.java:237)
  	at org.embulk.spi.FileInputRunner$RunnerControl$1.run(FileInputRunner.java:107)
  	at org.embulk.spi.util.Decoders$RecursiveControl.transaction(Decoders.java:68)
  	at org.embulk.spi.util.Decoders.transaction(Decoders.java:29)
  	at org.embulk.spi.FileInputRunner$RunnerControl.run(FileInputRunner.java:105)
  	at org.embulk.standards.LocalFileInputPlugin.resume(LocalFileInputPlugin.java:79)
  	at org.embulk.standards.LocalFileInputPlugin.transaction(LocalFileInputPlugin.java:72)
  	at org.embulk.spi.FileInputRunner.transaction(FileInputRunner.java:62)
  	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:507)
  	... 11 more

  Error: org.embulk.spi.DataException: There are 1,200 failures
  ```

## Examples of errors

- `MISSING_ARGUMENT`:

  ```
  2023-04-05 12:33:17.492 +0900 [ERROR] (0015:task-0000): [output sf_bulk_api failure] {"object":{"TextField__c":"12345678901","NumberField__c":1.23456789E9,"CheckboxField__c":true,"DateTimeField__c":"2019-12-31 16:01:01 UTC"},"errors":[{"code":"MISSING_ARGUMENT","message":"Id not specified in an update call","fields":[]}]}
  ```

- `MALFORMED_ID`:

  ```
  2023-04-05 12:42:04.164 +0900 [ERROR] (0016:task-0000): [output sf_bulk_api failure] {"object":{"Id":"xxxxxxxxxxxxxxxxxx","Name":"a022w00000ii7Jz","TextField__c":"1234567890","NumberField__c":1.23456789E9,"CheckboxField__c":true,"DateTimeField__c":"2019-12-31 16:01:01 UTC"},"errors":[{"code":"MALFORMED_ID","message":"カスタムオブジェクト ID: 不正な種別の ID 値: xxxxxxxxxxxxxxxxxx","fields":["Id"]}]}
  ```

- `STRING_TOO_LONG`:

  ```
  2023-04-05 09:45:35.563 +0900 [ERROR] (embulk-output-executor-4): [output sf_bulk_api failure] {"object":{"Id":"a022w00000ii7JsAAI","Name":"a022w00000ii7Js","TextField__c":"12345678901","NumberField__c":1.23456789E9,"CheckboxField__c":true,"DateTimeField__c":"2019-12-31 16:01:01 UTC"},"errors":[{"code":"STRING_TOO_LONG","message":"テキスト: データ値が大きすぎる: 12345678901 (max length\u003d10)","fields":["TextField__c"]}]}
  ```

- `NUMBER_OUTSIDE_VALID_RANGE`:

  ```
  2023-04-05 09:45:35.563 +0900 [ERROR] (embulk-output-executor-4): [output sf_bulk_api failure] {"object":{"Id":"a022w00000ii7JtAAI","Name":"a022w00000ii7Jt","TextField__c":"1234567890","NumberField__c":1.2345678901E10,"CheckboxField__c":true,"DateTimeField__c":"2019-12-31 16:01:01 UTC"},"errors":[{"code":"NUMBER_OUTSIDE_VALID_RANGE","message":"数値: 数値項目で有効な範囲を逸脱した値: 12345678901","fields":["NumberField__c"]}]}
  ```

- `DUPLICATE_VALUE`:

  ```
  2023-04-05 09:45:35.570 +0900 [ERROR] (embulk-output-executor-4): [output sf_bulk_api failure] {"object":{"Id":"a022w00000ii7JtAAI","Name":"a022w00000ii7Jt","TextField__c":"1234567890","NumberField__c":1.2345678901E10,"CheckboxField__c":true,"DateTimeField__c":"2019-12-31 16:01:01 UTC"},"errors":[{"code":"DUPLICATE_VALUE","message":"Maximum number of duplicate updates in one batch (12 allowed). Attempt to update Id more than once in this Api call: a022w00000ii7Jt","fields":[]}]}
  ```

- `EXCEEDED_ID_LIMIT`: *Continue even if exception*

  ```
  2023-04-05 12:44:47.960 +0900 [ERROR] (embulk-output-executor-2): [output sf_bulk_api failure] {"object":{"Id":"a022w00000ii7JqAAI","Name":"a022w00000ii7Jq","TextField__c":"12345678901","NumberField__c":1.23456789E9,"CheckboxField__c":true,"DateTimeField__c":"2019-12-31 16:01:01 UTC"},"errors":[{"code":"EXCEEDED_ID_LIMIT","message":"record limit reached. cannot submit more than 200 records into this call"}]}
  ```

- `INVALID_OPERATION_WITH_EXPIRED_PASSWORD`: *Abort by exception*

  ```
  2023-04-05 11:05:37.458 +0900 [ERROR] (0015:task-0000): [UnexpectedErrorFault [ApiFault  exceptionCode='INVALID_OPERATION_WITH_EXPIRED_PASSWORD'
   exceptionMessage='The users password has expired, you must call SetPassword before attempting any other API operations'
   extendedErrorDetails='{[0]}'
  ]
  ]

  org.embulk.output.sf_bulk_api.AbortException: [UnexpectedErrorFault [ApiFault  exceptionCode='INVALID_OPERATION_WITH_EXPIRED_PASSWORD'
   exceptionMessage='The users password has expired, you must call SetPassword before attempting any other API operations'
   extendedErrorDetails='{[0]}'
  ]
  ]

  	at org.embulk.output.sf_bulk_api.ErrorHandler.handleFault(ErrorHandler.java:41) ~[na:na]
  ```