### PR TITLE
Fix null handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Embulk output plugin for Salesforce Bulk API.
 - **object**: Salesforce object (sObject) type (string, required)
 - **action_type**: Action type (`insert`, `update`, or `upsert`, required)
 - **upsert_key**: Name of the external ID field (string, required when `upsert` action, default: `key`)
+- **ignore_nulls**: Whether to ignore nulls or set fields to null when column is null (boolean, default: `true`)
 - **throw_if_failed**: Whether to throw exception at the end of transaction if there are one or more failures (boolean, default: `true`)
 
 ## Example

--- a/src/main/java/org/embulk/output/sf_bulk_api/PluginTask.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/PluginTask.java
@@ -4,7 +4,7 @@ import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.Task;
 
-interface PluginTask extends Task {
+public interface PluginTask extends Task {
   @Config("username")
   String getUsername();
 

--- a/src/main/java/org/embulk/output/sf_bulk_api/PluginTask.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/PluginTask.java
@@ -32,6 +32,10 @@ public interface PluginTask extends Task {
   @ConfigDefault("\"key\"")
   String getUpsertKey();
 
+  @Config("ignore_nulls")
+  @ConfigDefault("\"true\"")
+  boolean getIgnoreNulls();
+
   @Config("throw_if_failed")
   @ConfigDefault("\"true\"")
   boolean getThrowIfFailed();

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
@@ -12,7 +12,7 @@ import org.joda.time.DateTimeZone;
 public class SForceColumnVisitor implements ColumnVisitor {
   private final SObject record;
   private final PageReader pageReader;
-  private static int MILLISECOND = 1000;
+  private static final int MILLISECOND = 1000;
 
   public SForceColumnVisitor(SObject record, PageReader pageReader) {
     this.record = record;
@@ -21,37 +21,57 @@ public class SForceColumnVisitor implements ColumnVisitor {
 
   @Override
   public void booleanColumn(Column column) {
-    record.addField(column.getName(), pageReader.getBoolean(column));
+    if (pageReader.isNull(column)) {
+      record.addField(column.getName(), null);
+    } else {
+      record.addField(column.getName(), pageReader.getBoolean(column));
+    }
   }
 
   @Override
   public void longColumn(Column column) {
-    record.addField(column.getName(), Long.toString(pageReader.getLong(column)));
+    if (pageReader.isNull(column)) {
+      record.addField(column.getName(), null);
+    } else {
+      record.addField(column.getName(), Long.toString(pageReader.getLong(column)));
+    }
   }
 
   @Override
   public void doubleColumn(Column column) {
-    record.addField(column.getName(), Double.toString(pageReader.getDouble(column)));
+    if (pageReader.isNull(column)) {
+      record.addField(column.getName(), null);
+    } else {
+      record.addField(column.getName(), Double.toString(pageReader.getDouble(column)));
+    }
   }
 
   @Override
   public void stringColumn(Column column) {
-    record.addField(column.getName(), pageReader.getString(column));
+    if (pageReader.isNull(column)) {
+      record.addField(column.getName(), null);
+    } else {
+      record.addField(column.getName(), pageReader.getString(column));
+    }
   }
 
   @Override
   public void timestampColumn(Column column) {
-    Timestamp timestamp = pageReader.getTimestamp(column);
-    if (timestamp != null) {
+    if (pageReader.isNull(column)) {
+      record.addField(column.getName(), null);
+    } else {
+      Timestamp timestamp = pageReader.getTimestamp(column);
       DateTime dateTime = new DateTime(timestamp.getEpochSecond() * MILLISECOND, DateTimeZone.UTC);
       record.addField(column.getName(), dateTime.toCalendar(Locale.ENGLISH));
-    } else {
-      record.addField(column.getName(), null);
     }
   }
 
   @Override
   public void jsonColumn(Column column) {
-    record.addField(column.getName(), pageReader.getString(column));
+    if (pageReader.isNull(column)) {
+      record.addField(column.getName(), null);
+    } else {
+      record.addField(column.getName(), pageReader.getString(column));
+    }
   }
 }

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -47,7 +47,10 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
       while (pageReader.nextRecord()) {
         final SObject record = new SObject();
         record.setType(this.pluginTask.getObject());
-        pageReader.getSchema().visitColumns(new SForceColumnVisitor(record, pageReader));
+        SForceColumnVisitor visitor =
+            new SForceColumnVisitor(record, pageReader, pluginTask.getIgnoreNulls());
+        pageReader.getSchema().visitColumns(visitor);
+        record.setFieldsToNull(visitor.getFieldsToNull());
         records.add(record);
         if (records.size() >= BATCH_SIZE) {
           try {


### PR DESCRIPTION
- Add check if column is null to ColumnVisitor to avoid reading indeterminate value from buffer allocated by [PooledByteBufAllocator](https://github.com/netty/netty/blob/4.0/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java).
- When column is null, allow to configure whether to ignore nulls or set fields to null.