### PR TITLE
fix: it failed when external id is not string type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
     testCompile "junit:junit:4.+"
+    testImplementation "org.mockito:mockito-inline:4.11.0"
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
@@ -42,7 +42,8 @@ public class SForceColumnVisitor implements ColumnVisitor {
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
-      record.addField(column.getName(), Long.toString(pageReader.getLong(column)));
+      // number type appears to be double type
+      record.addField(column.getName(), (double) pageReader.getLong(column));
     }
   }
 
@@ -51,7 +52,7 @@ public class SForceColumnVisitor implements ColumnVisitor {
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
-      record.addField(column.getName(), Double.toString(pageReader.getDouble(column)));
+      record.addField(column.getName(), pageReader.getDouble(column));
     }
   }
 

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
@@ -42,7 +42,9 @@ public class SForceColumnVisitor implements ColumnVisitor {
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
-      // number type appears to be double type
+      // The number in SaleForce is treated as a real number. So it is added as double type.
+      // https://help.salesforce.com/s/articleView?id=sf.custom_field_types.htm&type=5
+      // If it is added as long type, it couldn't upsert values correctly.
       record.addField(column.getName(), (double) pageReader.getLong(column));
     }
   }

--- a/src/test/java/org/embulk/output/sf_bulk_api/TestSForceColumnVisitor.java
+++ b/src/test/java/org/embulk/output/sf_bulk_api/TestSForceColumnVisitor.java
@@ -1,0 +1,40 @@
+package org.embulk.output.sf_bulk_api;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import com.sforce.soap.partner.sobject.SObject;
+import org.embulk.spi.Column;
+import org.embulk.spi.PageReader;
+import org.embulk.spi.type.Types;
+import org.junit.Test;
+
+public class TestSForceColumnVisitor {
+  private final PageReader pageReader = mock(PageReader.class);
+
+  @Test
+  public void testLongColumnNotNull() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "test", Types.LONG);
+    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
+
+    doReturn(false).when(pageReader).isNull(column);
+    doReturn(1L).when(pageReader).getLong(column);
+
+    visitor.longColumn(column);
+    assertEquals(1.0, record.getField("test"));
+  }
+
+  @Test
+  public void testDoubleColumnNotNull() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "test", Types.DOUBLE);
+    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
+
+    doReturn(false).when(pageReader).isNull(column);
+    doReturn(1.1).when(pageReader).getDouble(column);
+
+    visitor.doubleColumn(column);
+    assertEquals(1.1, record.getField("test"));
+  }
+}


### PR DESCRIPTION
If external id is not string type, it failed.
Because it changes value (long or double type) to string type.
