### PR TITLE
fix ErrorHandler to treat Long type field as double type

### DIFF
--- a/src/main/java/org/embulk/output/sf_bulk_api/ErrorHandler.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/ErrorHandler.java
@@ -146,10 +146,8 @@ public class ErrorHandler {
       return Timestamp.ofInstant(((Calendar) field).toInstant()).toString();
     } else if ("boolean".equals(type)) {
       return Boolean.valueOf(field.toString());
-    } else if ("double".equals(type)) {
+    } else if ("double".equals(type) || "long".equals(type)) {
       return Double.valueOf(field.toString());
-    } else if ("long".equals(type)) {
-      return Long.valueOf(field.toString());
     } else {
       return field.toString();
     }


### PR DESCRIPTION
In this PR (https://github.com/trocco-io/embulk-output-sf_bulk_api/pull/14), long type field is treated as double type.
So same change is needed in ErrorHandler.