### PR TITLE
Add Java 8 setup to GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,11 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: "zulu"
       - name: push gem
         uses: trocco-io/push-gem-to-gpr-action@v1
         with:


### PR DESCRIPTION
## Summary
- Add JDK 1.8 setup step to GitHub Actions workflow  
- Use Zulu distribution for Java 8 compatibility
- Ensure proper Java environment for build process
