### PR TITLE
Add configurable batch_size parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Embulk output plugin for Salesforce Bulk API.
 - **upsert_key**: Name of the external ID field (string, required when `upsert` action, default: `key`)
 - **ignore_nulls**: Whether to ignore nulls or set fields to null when column is null (boolean, default: `true`)
 - **throw_if_failed**: Whether to throw exception at the end of transaction if there are one or more failures (boolean, default: `true`)
+- **batch_size**: Number of records per API call (integer, default: `200`, min: `1`, max: `200`)
 
 ## Example
 

--- a/src/main/java/org/embulk/output/sf_bulk_api/PluginTask.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/PluginTask.java
@@ -56,6 +56,10 @@ public interface PluginTask extends Task {
   @ConfigDefault("\"true\"")
   boolean getThrowIfFailed();
 
+  @Config("batch_size")
+  @ConfigDefault("200")
+  int getBatchSize();
+
   @Config("error_records_detail_output_file")
   @ConfigDefault("null")
   Optional<String> getErrorRecordsDetailOutputFile();

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -18,7 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SForceTransactionalPageOutput implements TransactionalPageOutput {
-  private static final Long BATCH_SIZE = 200L;
+  private final int batchSize;
 
   private final ForceClient forceClient;
   private final PageReader pageReader;
@@ -38,6 +38,7 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
     this.pageReader = pageReader;
     this.pluginTask = pluginTask;
     this.errorHandler = errorHandler;
+    this.batchSize = pluginTask.getBatchSize();
   }
 
   @Override
@@ -53,7 +54,7 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
         pageReader.getSchema().visitColumns(visitor);
         record.setFieldsToNull(visitor.getFieldsToNull());
         records.add(record);
-        if (records.size() >= BATCH_SIZE) {
+        if (records.size() >= batchSize) {
           try {
             failures += forceClient.action(records);
             failed = failures != 0;

--- a/src/main/java/org/embulk/output/sf_bulk_api/SfBulkApiOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SfBulkApiOutputPlugin.java
@@ -35,6 +35,10 @@ public class SfBulkApiOutputPlugin implements OutputPlugin {
       ConfigSource config, org.embulk.spi.Schema schema, int taskCount, Control control) {
     final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
     final PluginTask task = configMapper.map(config, PluginTask.class);
+    int batchSize = task.getBatchSize();
+    if (batchSize < 1 || batchSize > 200) {
+      throw new ConfigException("batch_size must be between 1 and 200");
+    }
     final List<TaskReport> taskReports = control.run(task.dump());
     final long failures =
         taskReports.stream().mapToLong(taskReport -> taskReport.get(long.class, "failures")).sum();

--- a/src/test/java/org/embulk/output/sf_bulk_api/TestSfBulkApiFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sf_bulk_api/TestSfBulkApiFileOutputPlugin.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.exec.PartialExecutionException;
 import org.embulk.input.file.LocalFileInputPlugin;
@@ -236,6 +237,52 @@ public class TestSfBulkApiFileOutputPlugin {
           Util.readResource("logoutRequestBody.xml"),
           Util.toStringFromGZip(mockWebServer.takeRequest()));
     }
+  }
+
+  @Test
+  public void testBatchSizeZero() {
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer).set("action_type", "insert").set("batch_size", 0);
+    PartialExecutionException e =
+        assertThrows(
+            PartialExecutionException.class,
+            () ->
+                embulk.runOutput(
+                    config, Util.createInputFile(testFolder, "id:string", "id0").toPath()));
+    assertEquals(ConfigException.class, e.getCause().getClass());
+  }
+
+  @Test
+  public void testBatchSizeOver200() {
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer).set("action_type", "insert").set("batch_size", 201);
+    PartialExecutionException e =
+        assertThrows(
+            PartialExecutionException.class,
+            () ->
+                embulk.runOutput(
+                    config, Util.createInputFile(testFolder, "id:string", "id0").toPath()));
+    assertEquals(ConfigException.class, e.getCause().getClass());
+  }
+
+  @Test
+  public void testBatchSizeCustom() throws IOException, InterruptedException {
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer).set("action_type", "insert").set("batch_size", 1);
+    PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, PluginTask.class);
+
+    // 2 records with batch_size=1 → 2 API calls
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse(task.getActionType(), 1));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse(task.getActionType(), 1));
+    for (int i = 0; i < 2; i++) {
+      mockWebServer.enqueue(mockResponse("logoutResponseBody.xml"));
+    }
+    File in = Util.createInputFile(testFolder, "id:string", "id0", "id1");
+    embulk.runOutput(config, in.toPath());
+
+    // login + 2 action calls + 2 logout = 5
+    assertEquals(5, mockWebServer.getRequestCount());
   }
 
   private static String[] concat(String[] src, String elem) {


### PR DESCRIPTION
## Summary
- Add `batch_size` parameter to allow users to configure the number of records per Partner API call (range: 1-200, default: 200)
- When Salesforce Apex Triggers hit governor limits due to large batch sizes, users can reduce `batch_size` to mitigate the issue
- Add validation, tests, and README documentation

## Test plan
- [x] `batch_size: 0` throws `ConfigException`
- [x] `batch_size: 201` throws `ConfigException`
- [x] `batch_size: 1` with 2 records results in 2 API calls (batch splitting)
- [x] All existing tests pass (backward compatibility with default value 200)

Related: https://github.com/primenumber-dev/n-transfer-ui/issues/31378

🤖 Generated with [Claude Code](https://claude.com/claude-code)