### PR TITLE
Add associations config for external ID reference field resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Embulk output plugin for Salesforce Bulk API.
 - **ignore_nulls**: Whether to ignore nulls or set fields to null when column is null (boolean, default: `true`)
 - **throw_if_failed**: Whether to throw exception at the end of transaction if there are one or more failures (boolean, default: `true`)
 - **batch_size**: Number of records per API call (integer, default: `200`, min: `1`, max: `200`)
+- **update_key**: Field name to resolve records by external key for `update` action. The plugin queries Salesforce to map the key to record IDs before updating. (string, optional)
+- **error_records_detail_output_file**: File path to write detailed error records in JSONL format (string, optional)
+- **associations**: List of reference field associations to set via external ID lookup. Salesforce resolves the external ID server-side using nested SObjects — no additional API calls are needed. (list, default: `[]`)
+  - **reference_field**: API name of the reference field (e.g. `AccountId`, `Company__c`)
+  - **referenced_object**: API name of the referenced object type (e.g. `Account`, `TestCompany__c`)
+  - **unique_key**: Field on the referenced object used for matching (e.g. `External_Id__c`)
+  - **source_column**: Input column name containing the external ID value
 
 ## Example
 
@@ -52,6 +59,29 @@ out:
   action_type: upsert
   upsert_key: Name
 ```
+
+### With associations (external ID reference)
+```yaml
+out:
+  type: sf_bulk_api
+  auth_method: oauth
+  server_url: server_url
+  access_token: access_token
+  object: Contact
+  action_type: upsert
+  upsert_key: Employee_Code__c
+  associations:
+    - reference_field: AccountId
+      referenced_object: Account
+      unique_key: External_Id__c
+      source_column: account_code
+    - reference_field: OwnerId
+      referenced_object: User
+      unique_key: Username
+      source_column: owner_username
+```
+
+In this example, the `account_code` input column is used to look up an `Account` by its `External_Id__c` field and set the `AccountId` reference. The `owner_username` column resolves a `User` by `Username` for the polymorphic `OwnerId` field. Salesforce resolves these references server-side within the same API call.
 
 ## Build
 

--- a/src/main/java/org/embulk/output/sf_bulk_api/AssociationConfig.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/AssociationConfig.java
@@ -1,0 +1,28 @@
+package org.embulk.output.sf_bulk_api;
+
+import org.embulk.util.config.Config;
+import org.embulk.util.config.Task;
+
+public interface AssociationConfig extends Task {
+  @Config("reference_field")
+  String getReferenceField();
+
+  @Config("referenced_object")
+  String getReferencedObject();
+
+  @Config("unique_key")
+  String getUniqueKey();
+
+  @Config("source_column")
+  String getSourceColumn();
+
+  static String deriveRelationshipName(String referenceField) {
+    if (referenceField.endsWith("__c")) {
+      return referenceField.substring(0, referenceField.length() - 3) + "__r";
+    }
+    if (referenceField.endsWith("Id")) {
+      return referenceField.substring(0, referenceField.length() - 2);
+    }
+    return referenceField;
+  }
+}

--- a/src/main/java/org/embulk/output/sf_bulk_api/AssociationConfig.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/AssociationConfig.java
@@ -1,5 +1,6 @@
 package org.embulk.output.sf_bulk_api;
 
+import org.embulk.config.ConfigException;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.Task;
 
@@ -37,6 +38,10 @@ public interface AssociationConfig extends Task {
     if (referenceField.endsWith("Id")) {
       return referenceField.substring(0, referenceField.length() - 2);
     }
-    return referenceField;
+    throw new ConfigException(
+        String.format(
+            "Cannot derive relationship name from reference_field '%s'."
+                + " Expected a standard field ending with 'Id' or a custom field ending with '__c'.",
+            referenceField));
   }
 }

--- a/src/main/java/org/embulk/output/sf_bulk_api/AssociationConfig.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/AssociationConfig.java
@@ -16,6 +16,20 @@ public interface AssociationConfig extends Task {
   @Config("source_column")
   String getSourceColumn();
 
+  /**
+   * Derives the Salesforce relationship name from a reference field API name. The Partner SOAP API
+   * requires the relationship name (not the field API name) when setting nested SObjects.
+   *
+   * <p>Salesforce naming conventions:
+   *
+   * <ul>
+   *   <li>Standard fields: strip trailing "Id" (e.g. AccountId → Account, OwnerId → Owner)
+   *   <li>Custom fields: replace "__c" with "__r" (e.g. Company__c → Company__r)
+   * </ul>
+   *
+   * The __c check comes first because a custom field could contain "Id" in its name (e.g. SomeId__c
+   * → SomeId__r, not SomeId_).
+   */
   static String deriveRelationshipName(String referenceField) {
     if (referenceField.endsWith("__c")) {
       return referenceField.substring(0, referenceField.length() - 3) + "__r";

--- a/src/main/java/org/embulk/output/sf_bulk_api/PluginTask.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/PluginTask.java
@@ -1,5 +1,6 @@
 package org.embulk.output.sf_bulk_api;
 
+import java.util.List;
 import java.util.Optional;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
@@ -67,4 +68,8 @@ public interface PluginTask extends Task {
   @Config("error_records_detail_output_file")
   @ConfigDefault("null")
   Optional<String> getErrorRecordsDetailOutputFile();
+
+  @Config("associations")
+  @ConfigDefault("[]")
+  List<AssociationConfig> getAssociations();
 }

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
@@ -3,10 +3,8 @@ package org.embulk.output.sf_bulk_api;
 import com.sforce.soap.partner.sobject.SObject;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.PageReader;
@@ -16,18 +14,11 @@ public class SForceColumnVisitor implements ColumnVisitor {
   private final SObject record;
   private final PageReader pageReader;
   private final boolean ignoreNulls;
-  private final Set<String> skipColumns;
 
-  public SForceColumnVisitor(
-      SObject record, PageReader pageReader, boolean ignoreNulls, Set<String> skipColumns) {
+  public SForceColumnVisitor(SObject record, PageReader pageReader, boolean ignoreNulls) {
     this.record = record;
     this.pageReader = pageReader;
     this.ignoreNulls = ignoreNulls;
-    this.skipColumns = skipColumns;
-  }
-
-  public SForceColumnVisitor(SObject record, PageReader pageReader, boolean ignoreNulls) {
-    this(record, pageReader, ignoreNulls, Collections.emptySet());
   }
 
   public String[] getFieldsToNull() {
@@ -36,9 +27,6 @@ public class SForceColumnVisitor implements ColumnVisitor {
 
   @Override
   public void booleanColumn(Column column) {
-    if (skipColumns.contains(column.getName())) {
-      return;
-    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
@@ -48,9 +36,6 @@ public class SForceColumnVisitor implements ColumnVisitor {
 
   @Override
   public void longColumn(Column column) {
-    if (skipColumns.contains(column.getName())) {
-      return;
-    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
@@ -63,9 +48,6 @@ public class SForceColumnVisitor implements ColumnVisitor {
 
   @Override
   public void doubleColumn(Column column) {
-    if (skipColumns.contains(column.getName())) {
-      return;
-    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
@@ -75,9 +57,6 @@ public class SForceColumnVisitor implements ColumnVisitor {
 
   @Override
   public void stringColumn(Column column) {
-    if (skipColumns.contains(column.getName())) {
-      return;
-    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
@@ -89,9 +68,6 @@ public class SForceColumnVisitor implements ColumnVisitor {
   @SuppressWarnings("deprecation")
   @Override
   public void timestampColumn(Column column) {
-    if (skipColumns.contains(column.getName())) {
-      return;
-    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
@@ -105,9 +81,6 @@ public class SForceColumnVisitor implements ColumnVisitor {
   @SuppressWarnings("deprecation") // For the use of pageReader.getJson
   @Override
   public void jsonColumn(Column column) {
-    if (skipColumns.contains(column.getName())) {
-      return;
-    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
@@ -17,7 +17,6 @@ public class SForceColumnVisitor implements ColumnVisitor {
   private final PageReader pageReader;
   private final boolean ignoreNulls;
   private final Set<String> skipColumns;
-  private static final int MILLISECOND = 1000;
 
   public SForceColumnVisitor(
       SObject record, PageReader pageReader, boolean ignoreNulls, Set<String> skipColumns) {

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceColumnVisitor.java
@@ -3,8 +3,10 @@ package org.embulk.output.sf_bulk_api;
 import com.sforce.soap.partner.sobject.SObject;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.PageReader;
@@ -14,12 +16,19 @@ public class SForceColumnVisitor implements ColumnVisitor {
   private final SObject record;
   private final PageReader pageReader;
   private final boolean ignoreNulls;
+  private final Set<String> skipColumns;
   private static final int MILLISECOND = 1000;
 
-  public SForceColumnVisitor(SObject record, PageReader pageReader, boolean ignoreNulls) {
+  public SForceColumnVisitor(
+      SObject record, PageReader pageReader, boolean ignoreNulls, Set<String> skipColumns) {
     this.record = record;
     this.pageReader = pageReader;
     this.ignoreNulls = ignoreNulls;
+    this.skipColumns = skipColumns;
+  }
+
+  public SForceColumnVisitor(SObject record, PageReader pageReader, boolean ignoreNulls) {
+    this(record, pageReader, ignoreNulls, Collections.emptySet());
   }
 
   public String[] getFieldsToNull() {
@@ -28,6 +37,9 @@ public class SForceColumnVisitor implements ColumnVisitor {
 
   @Override
   public void booleanColumn(Column column) {
+    if (skipColumns.contains(column.getName())) {
+      return;
+    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
@@ -37,6 +49,9 @@ public class SForceColumnVisitor implements ColumnVisitor {
 
   @Override
   public void longColumn(Column column) {
+    if (skipColumns.contains(column.getName())) {
+      return;
+    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
@@ -49,6 +64,9 @@ public class SForceColumnVisitor implements ColumnVisitor {
 
   @Override
   public void doubleColumn(Column column) {
+    if (skipColumns.contains(column.getName())) {
+      return;
+    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
@@ -58,6 +76,9 @@ public class SForceColumnVisitor implements ColumnVisitor {
 
   @Override
   public void stringColumn(Column column) {
+    if (skipColumns.contains(column.getName())) {
+      return;
+    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
@@ -69,6 +90,9 @@ public class SForceColumnVisitor implements ColumnVisitor {
   @SuppressWarnings("deprecation")
   @Override
   public void timestampColumn(Column column) {
+    if (skipColumns.contains(column.getName())) {
+      return;
+    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {
@@ -82,6 +106,9 @@ public class SForceColumnVisitor implements ColumnVisitor {
   @SuppressWarnings("deprecation") // For the use of pageReader.getJson
   @Override
   public void jsonColumn(Column column) {
+    if (skipColumns.contains(column.getName())) {
+      return;
+    }
     if (pageReader.isNull(column)) {
       addFieldsToNull(column);
     } else {

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -5,11 +5,17 @@ import static org.embulk.output.sf_bulk_api.SfBulkApiOutputPlugin.CONFIG_MAPPER_
 import com.sforce.soap.partner.fault.ApiFault;
 import com.sforce.soap.partner.sobject.SObject;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
+import org.embulk.config.ConfigException;
 import org.embulk.config.TaskReport;
+import org.embulk.spi.Column;
 import org.embulk.spi.Page;
 import org.embulk.spi.PageReader;
+import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +27,8 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
   private final PageReader pageReader;
   private final PluginTask pluginTask;
   private final ErrorHandler errorHandler;
+  private final List<AssociationConfig> associations;
+  private final Set<String> associationSourceColumns;
 
   private final Logger logger = LoggerFactory.getLogger(SForceTransactionalPageOutput.class);
   private boolean failed;
@@ -36,6 +44,9 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
     this.pluginTask = pluginTask;
     this.errorHandler = errorHandler;
     this.batchSize = pluginTask.getBatchSize();
+    this.associations = pluginTask.getAssociations();
+    this.associationSourceColumns =
+        associations.stream().map(AssociationConfig::getSourceColumn).collect(Collectors.toSet());
   }
 
   @Override
@@ -47,9 +58,28 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
         final SObject record = new SObject();
         record.setType(this.pluginTask.getObject());
         SForceColumnVisitor visitor =
-            new SForceColumnVisitor(record, pageReader, pluginTask.getIgnoreNulls());
+            new SForceColumnVisitor(
+                record, pageReader, pluginTask.getIgnoreNulls(), associationSourceColumns);
         pageReader.getSchema().visitColumns(visitor);
-        record.setFieldsToNull(visitor.getFieldsToNull());
+
+        List<String> fieldsToNull = new ArrayList<>(Arrays.asList(visitor.getFieldsToNull()));
+        for (AssociationConfig assoc : associations) {
+          Column sourceCol = findColumn(pageReader.getSchema(), assoc.getSourceColumn());
+          if (pageReader.isNull(sourceCol)) {
+            if (!pluginTask.getIgnoreNulls()) {
+              fieldsToNull.add(assoc.getReferenceField());
+            }
+          } else {
+            String value = readColumnAsString(pageReader, sourceCol);
+            String relationshipName =
+                AssociationConfig.deriveRelationshipName(assoc.getReferenceField());
+            SObject refObject = new SObject();
+            refObject.setType(assoc.getReferencedObject());
+            refObject.setField(assoc.getUniqueKey(), value);
+            record.setField(relationshipName, refObject);
+          }
+        }
+        record.setFieldsToNull(fieldsToNull.toArray(new String[0]));
         records.add(record);
         if (records.size() >= batchSize) {
           try {
@@ -101,6 +131,33 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
 
   @Override
   public void abort() {}
+
+  private Column findColumn(Schema schema, String columnName) {
+    return schema.getColumns().stream()
+        .filter(col -> col.getName().equals(columnName))
+        .findFirst()
+        .orElseThrow(() -> new ConfigException("Column not found: " + columnName));
+  }
+
+  @SuppressWarnings("deprecation")
+  private String readColumnAsString(PageReader reader, Column column) {
+    switch (column.getType().getName()) {
+      case "string":
+        return reader.getString(column);
+      case "long":
+        return String.valueOf(reader.getLong(column));
+      case "double":
+        return String.valueOf(reader.getDouble(column));
+      case "boolean":
+        return String.valueOf(reader.getBoolean(column));
+      case "timestamp":
+        return reader.getTimestamp(column).getInstant().toString();
+      case "json":
+        return reader.getJson(column).toJson();
+      default:
+        return reader.getString(column);
+    }
+  }
 
   @Override
   public TaskReport commit() {

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -65,9 +65,13 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
         final SObject record = new SObject();
         record.setType(this.pluginTask.getObject());
         SForceColumnVisitor visitor =
-            new SForceColumnVisitor(
-                record, pageReader, pluginTask.getIgnoreNulls(), associationSourceColumns);
-        pageReader.getSchema().visitColumns(visitor);
+            new SForceColumnVisitor(record, pageReader, pluginTask.getIgnoreNulls());
+        // Visit only non-association columns. Association source_columns are not
+        // Salesforce fields and must be skipped from direct SObject field assignment.
+        // Their values are read separately in the association processing below.
+        pageReader.getSchema().getColumns().stream()
+            .filter(col -> !associationSourceColumns.contains(col.getName()))
+            .forEach(col -> col.visit(visitor));
 
         List<String> fieldsToNull = new ArrayList<>(Arrays.asList(visitor.getFieldsToNull()));
         for (Map.Entry<AssociationConfig, Column> entry : associationColumns.entrySet()) {

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -6,7 +6,9 @@ import com.sforce.soap.partner.fault.ApiFault;
 import com.sforce.soap.partner.sobject.SObject;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
@@ -27,7 +29,7 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
   private final PageReader pageReader;
   private final PluginTask pluginTask;
   private final ErrorHandler errorHandler;
-  private final List<AssociationConfig> associations;
+  private final Map<AssociationConfig, Column> associationColumns;
   private final Set<String> associationSourceColumns;
 
   private final Logger logger = LoggerFactory.getLogger(SForceTransactionalPageOutput.class);
@@ -44,7 +46,12 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
     this.pluginTask = pluginTask;
     this.errorHandler = errorHandler;
     this.batchSize = pluginTask.getBatchSize();
-    this.associations = pluginTask.getAssociations();
+    Schema schema = pageReader.getSchema();
+    List<AssociationConfig> associations = pluginTask.getAssociations();
+    this.associationColumns = new LinkedHashMap<>();
+    for (AssociationConfig assoc : associations) {
+      associationColumns.put(assoc, findColumn(schema, assoc.getSourceColumn()));
+    }
     this.associationSourceColumns =
         associations.stream().map(AssociationConfig::getSourceColumn).collect(Collectors.toSet());
   }
@@ -63,8 +70,9 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
         pageReader.getSchema().visitColumns(visitor);
 
         List<String> fieldsToNull = new ArrayList<>(Arrays.asList(visitor.getFieldsToNull()));
-        for (AssociationConfig assoc : associations) {
-          Column sourceCol = findColumn(pageReader.getSchema(), assoc.getSourceColumn());
+        for (Map.Entry<AssociationConfig, Column> entry : associationColumns.entrySet()) {
+          AssociationConfig assoc = entry.getKey();
+          Column sourceCol = entry.getValue();
           if (pageReader.isNull(sourceCol)) {
             if (!pluginTask.getIgnoreNulls()) {
               fieldsToNull.add(assoc.getReferenceField());

--- a/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SForceTransactionalPageOutput.java
@@ -163,7 +163,10 @@ public class SForceTransactionalPageOutput implements TransactionalPageOutput {
       case "json":
         return reader.getJson(column).toJson();
       default:
-        return reader.getString(column);
+        throw new ConfigException(
+            String.format(
+                "Unsupported column type '%s' for association source_column '%s'",
+                column.getType().getName(), column.getName()));
     }
   }
 

--- a/src/main/java/org/embulk/output/sf_bulk_api/SfBulkApiOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SfBulkApiOutputPlugin.java
@@ -7,7 +7,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
@@ -49,6 +51,22 @@ public class SfBulkApiOutputPlugin implements OutputPlugin {
       if (!exists) {
         throw new ConfigException(
             String.format("update_key '%s' does not exist in input schema", updateKey));
+      }
+    }
+    Set<String> seenReferenceFields = new HashSet<>();
+    for (AssociationConfig assoc : task.getAssociations()) {
+      boolean exists =
+          schema.getColumns().stream()
+              .anyMatch(col -> col.getName().equals(assoc.getSourceColumn()));
+      if (!exists) {
+        throw new ConfigException(
+            String.format(
+                "association source_column '%s' does not exist in input schema",
+                assoc.getSourceColumn()));
+      }
+      if (!seenReferenceFields.add(assoc.getReferenceField())) {
+        throw new ConfigException(
+            String.format("duplicate association reference_field '%s'", assoc.getReferenceField()));
       }
     }
     final List<TaskReport> taskReports = control.run(task.dump());

--- a/src/main/java/org/embulk/output/sf_bulk_api/SfBulkApiOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sf_bulk_api/SfBulkApiOutputPlugin.java
@@ -55,6 +55,18 @@ public class SfBulkApiOutputPlugin implements OutputPlugin {
     }
     Set<String> seenReferenceFields = new HashSet<>();
     for (AssociationConfig assoc : task.getAssociations()) {
+      if (assoc.getReferenceField().isEmpty()) {
+        throw new ConfigException("association reference_field must not be empty");
+      }
+      if (assoc.getReferencedObject().isEmpty()) {
+        throw new ConfigException("association referenced_object must not be empty");
+      }
+      if (assoc.getUniqueKey().isEmpty()) {
+        throw new ConfigException("association unique_key must not be empty");
+      }
+      if (assoc.getSourceColumn().isEmpty()) {
+        throw new ConfigException("association source_column must not be empty");
+      }
       boolean exists =
           schema.getColumns().stream()
               .anyMatch(col -> col.getName().equals(assoc.getSourceColumn()));

--- a/src/test/java/org/embulk/output/sf_bulk_api/TestAssociationConfig.java
+++ b/src/test/java/org/embulk/output/sf_bulk_api/TestAssociationConfig.java
@@ -1,7 +1,9 @@
 package org.embulk.output.sf_bulk_api;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
+import org.embulk.config.ConfigException;
 import org.junit.Test;
 
 public class TestAssociationConfig {
@@ -64,9 +66,16 @@ public class TestAssociationConfig {
   }
 
   @Test
-  public void testDeriveRelationshipNameFallback() {
-    // Neither __c nor Id suffix → returned as-is
-    assertEquals("SomeField", AssociationConfig.deriveRelationshipName("SomeField"));
+  public void testDeriveRelationshipNameFallbackThrows() {
+    // Neither __c nor Id suffix → ConfigException
+    ConfigException e =
+        assertThrows(
+            ConfigException.class,
+            () -> AssociationConfig.deriveRelationshipName("SomeField"));
+    assertEquals(
+        "Cannot derive relationship name from reference_field 'SomeField'."
+            + " Expected a standard field ending with 'Id' or a custom field ending with '__c'.",
+        e.getMessage());
   }
 
   @Test

--- a/src/test/java/org/embulk/output/sf_bulk_api/TestAssociationConfig.java
+++ b/src/test/java/org/embulk/output/sf_bulk_api/TestAssociationConfig.java
@@ -70,8 +70,7 @@ public class TestAssociationConfig {
     // Neither __c nor Id suffix → ConfigException
     ConfigException e =
         assertThrows(
-            ConfigException.class,
-            () -> AssociationConfig.deriveRelationshipName("SomeField"));
+            ConfigException.class, () -> AssociationConfig.deriveRelationshipName("SomeField"));
     assertEquals(
         "Cannot derive relationship name from reference_field 'SomeField'."
             + " Expected a standard field ending with 'Id' or a custom field ending with '__c'.",

--- a/src/test/java/org/embulk/output/sf_bulk_api/TestAssociationConfig.java
+++ b/src/test/java/org/embulk/output/sf_bulk_api/TestAssociationConfig.java
@@ -1,0 +1,77 @@
+package org.embulk.output.sf_bulk_api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TestAssociationConfig {
+
+  // --- deriveRelationshipName: standard fields (end with "Id") ---
+
+  @Test
+  public void testDeriveRelationshipNameAccountId() {
+    assertEquals("Account", AssociationConfig.deriveRelationshipName("AccountId"));
+  }
+
+  @Test
+  public void testDeriveRelationshipNameParentId() {
+    assertEquals("Parent", AssociationConfig.deriveRelationshipName("ParentId"));
+  }
+
+  @Test
+  public void testDeriveRelationshipNameOwnerId() {
+    assertEquals("Owner", AssociationConfig.deriveRelationshipName("OwnerId"));
+  }
+
+  @Test
+  public void testDeriveRelationshipNameReportsToId() {
+    assertEquals("ReportsTo", AssociationConfig.deriveRelationshipName("ReportsToId"));
+  }
+
+  @Test
+  public void testDeriveRelationshipNameCreatedById() {
+    assertEquals("CreatedBy", AssociationConfig.deriveRelationshipName("CreatedById"));
+  }
+
+  @Test
+  public void testDeriveRelationshipNameLastModifiedById() {
+    assertEquals("LastModifiedBy", AssociationConfig.deriveRelationshipName("LastModifiedById"));
+  }
+
+  // --- deriveRelationshipName: custom fields (end with "__c") ---
+
+  @Test
+  public void testDeriveRelationshipNameCustomField() {
+    assertEquals("My_Account__r", AssociationConfig.deriveRelationshipName("My_Account__c"));
+  }
+
+  @Test
+  public void testDeriveRelationshipNameCustomFieldAnother() {
+    assertEquals("Custom_Field__r", AssociationConfig.deriveRelationshipName("Custom_Field__c"));
+  }
+
+  @Test
+  public void testDeriveRelationshipNameCustomFieldSimple() {
+    assertEquals("Company__r", AssociationConfig.deriveRelationshipName("Company__c"));
+  }
+
+  // --- deriveRelationshipName: edge cases ---
+
+  @Test
+  public void testDeriveRelationshipNameCustomFieldTakesPrecedenceOverId() {
+    // A field ending with "__c" should be treated as custom even if it also contains "Id"
+    assertEquals("SomeId__r", AssociationConfig.deriveRelationshipName("SomeId__c"));
+  }
+
+  @Test
+  public void testDeriveRelationshipNameFallback() {
+    // Neither __c nor Id suffix → returned as-is
+    assertEquals("SomeField", AssociationConfig.deriveRelationshipName("SomeField"));
+  }
+
+  @Test
+  public void testDeriveRelationshipNameJustId() {
+    // "Id" alone → empty string (edge case, unlikely in practice)
+    assertEquals("", AssociationConfig.deriveRelationshipName("Id"));
+  }
+}

--- a/src/test/java/org/embulk/output/sf_bulk_api/TestSForceColumnVisitor.java
+++ b/src/test/java/org/embulk/output/sf_bulk_api/TestSForceColumnVisitor.java
@@ -2,15 +2,10 @@ package org.embulk.output.sf_bulk_api;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
 import com.sforce.soap.partner.sobject.SObject;
-import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.type.Types;
@@ -19,7 +14,20 @@ import org.junit.Test;
 public class TestSForceColumnVisitor {
   private final PageReader pageReader = mock(PageReader.class);
 
-  // --- Existing basic type tests ---
+  // --- Basic type tests ---
+
+  @Test
+  public void testBooleanColumnNotNull() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "test", Types.BOOLEAN);
+    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
+
+    doReturn(false).when(pageReader).isNull(column);
+    doReturn(true).when(pageReader).getBoolean(column);
+
+    visitor.booleanColumn(column);
+    assertEquals(true, record.getField("test"));
+  }
 
   @Test
   public void testLongColumnNotNull() {
@@ -47,6 +55,19 @@ public class TestSForceColumnVisitor {
     assertEquals(1.1, record.getField("test"));
   }
 
+  @Test
+  public void testStringColumnNotNull() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "test", Types.STRING);
+    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
+
+    doReturn(false).when(pageReader).isNull(column);
+    doReturn("hello").when(pageReader).getString(column);
+
+    visitor.stringColumn(column);
+    assertEquals("hello", record.getField("test"));
+  }
+
   @SuppressWarnings("deprecation")
   @Test
   public void testTimestampColumnNotNull() {
@@ -61,195 +82,10 @@ public class TestSForceColumnVisitor {
     assertEquals(100, ((Calendar) record.getField("test")).getTimeInMillis());
   }
 
-  // --- skipColumns: string ---
+  // --- Null handling: ignore_nulls=false ---
 
   @Test
-  public void testSkipColumnString() {
-    final SObject record = new SObject();
-    final Column column = new Column(0, "account_code", Types.STRING);
-    Set<String> skipColumns = new HashSet<>(Collections.singletonList("account_code"));
-    final SForceColumnVisitor visitor =
-        new SForceColumnVisitor(record, pageReader, false, skipColumns);
-
-    doReturn(false).when(pageReader).isNull(column);
-    doReturn("COMP-001").when(pageReader).getString(column);
-
-    visitor.stringColumn(column);
-    assertNull(record.getField("account_code"));
-  }
-
-  // --- skipColumns: all other types ---
-
-  @Test
-  public void testSkipColumnBoolean() {
-    final SObject record = new SObject();
-    final Column column = new Column(0, "skip_bool", Types.BOOLEAN);
-    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_bool"));
-    final SForceColumnVisitor visitor =
-        new SForceColumnVisitor(record, pageReader, false, skipColumns);
-
-    doReturn(false).when(pageReader).isNull(column);
-    doReturn(true).when(pageReader).getBoolean(column);
-
-    visitor.booleanColumn(column);
-    assertNull(record.getField("skip_bool"));
-  }
-
-  @Test
-  public void testSkipColumnLong() {
-    final SObject record = new SObject();
-    final Column column = new Column(0, "skip_long", Types.LONG);
-    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_long"));
-    final SForceColumnVisitor visitor =
-        new SForceColumnVisitor(record, pageReader, false, skipColumns);
-
-    doReturn(false).when(pageReader).isNull(column);
-    doReturn(42L).when(pageReader).getLong(column);
-
-    visitor.longColumn(column);
-    assertNull(record.getField("skip_long"));
-  }
-
-  @Test
-  public void testSkipColumnDouble() {
-    final SObject record = new SObject();
-    final Column column = new Column(0, "skip_double", Types.DOUBLE);
-    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_double"));
-    final SForceColumnVisitor visitor =
-        new SForceColumnVisitor(record, pageReader, false, skipColumns);
-
-    doReturn(false).when(pageReader).isNull(column);
-    doReturn(3.14).when(pageReader).getDouble(column);
-
-    visitor.doubleColumn(column);
-    assertNull(record.getField("skip_double"));
-  }
-
-  @SuppressWarnings("deprecation")
-  @Test
-  public void testSkipColumnTimestamp() {
-    final SObject record = new SObject();
-    final Column column = new Column(0, "skip_ts", Types.TIMESTAMP);
-    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_ts"));
-    final SForceColumnVisitor visitor =
-        new SForceColumnVisitor(record, pageReader, false, skipColumns);
-
-    doReturn(false).when(pageReader).isNull(column);
-    doReturn(org.embulk.spi.time.Timestamp.ofEpochMilli(100)).when(pageReader).getTimestamp(column);
-
-    visitor.timestampColumn(column);
-    assertNull(record.getField("skip_ts"));
-  }
-
-  @SuppressWarnings("deprecation")
-  @Test
-  public void testSkipColumnJson() {
-    final SObject record = new SObject();
-    final Column column = new Column(0, "skip_json", Types.JSON);
-    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_json"));
-    final SForceColumnVisitor visitor =
-        new SForceColumnVisitor(record, pageReader, false, skipColumns);
-
-    doReturn(false).when(pageReader).isNull(column);
-
-    visitor.jsonColumn(column);
-    assertNull(record.getField("skip_json"));
-  }
-
-  // --- skipColumns: null handling ---
-
-  @Test
-  public void testSkipColumnNullNotAddedToFieldsToNull() {
-    final SObject record = new SObject();
-    final Column column = new Column(0, "account_code", Types.STRING);
-    Set<String> skipColumns = new HashSet<>(Collections.singletonList("account_code"));
-    final SForceColumnVisitor visitor =
-        new SForceColumnVisitor(record, pageReader, false, skipColumns);
-
-    doReturn(true).when(pageReader).isNull(column);
-
-    visitor.stringColumn(column);
-    assertArrayEquals(new String[0], visitor.getFieldsToNull());
-  }
-
-  @Test
-  public void testSkipColumnNullLongNotAddedToFieldsToNull() {
-    final SObject record = new SObject();
-    final Column column = new Column(0, "skip_long", Types.LONG);
-    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_long"));
-    final SForceColumnVisitor visitor =
-        new SForceColumnVisitor(record, pageReader, false, skipColumns);
-
-    doReturn(true).when(pageReader).isNull(column);
-
-    visitor.longColumn(column);
-    assertArrayEquals(new String[0], visitor.getFieldsToNull());
-  }
-
-  // --- skipColumns: mixed with non-skip columns ---
-
-  @Test
-  public void testNonSkipColumnStillProcessed() {
-    final SObject record = new SObject();
-    final Column normalCol = new Column(0, "FirstName", Types.STRING);
-    final Column skipCol = new Column(1, "account_code", Types.STRING);
-    Set<String> skipColumns = new HashSet<>(Collections.singletonList("account_code"));
-    final SForceColumnVisitor visitor =
-        new SForceColumnVisitor(record, pageReader, false, skipColumns);
-
-    doReturn(false).when(pageReader).isNull(normalCol);
-    doReturn("John").when(pageReader).getString(normalCol);
-    doReturn(false).when(pageReader).isNull(skipCol);
-    doReturn("COMP-001").when(pageReader).getString(skipCol);
-
-    visitor.stringColumn(normalCol);
-    visitor.stringColumn(skipCol);
-    assertEquals("John", record.getField("FirstName"));
-    assertNull(record.getField("account_code"));
-  }
-
-  @Test
-  public void testMultipleSkipColumns() {
-    final SObject record = new SObject();
-    final Column col1 = new Column(0, "Name", Types.STRING);
-    final Column col2 = new Column(1, "code1", Types.STRING);
-    final Column col3 = new Column(2, "code2", Types.STRING);
-    Set<String> skipColumns = new HashSet<>(Arrays.asList("code1", "code2"));
-    final SForceColumnVisitor visitor =
-        new SForceColumnVisitor(record, pageReader, false, skipColumns);
-
-    doReturn(false).when(pageReader).isNull(col1);
-    doReturn("John").when(pageReader).getString(col1);
-    doReturn(false).when(pageReader).isNull(col2);
-    doReturn("A").when(pageReader).getString(col2);
-    doReturn(false).when(pageReader).isNull(col3);
-    doReturn("B").when(pageReader).getString(col3);
-
-    visitor.stringColumn(col1);
-    visitor.stringColumn(col2);
-    visitor.stringColumn(col3);
-    assertEquals("John", record.getField("Name"));
-    assertNull(record.getField("code1"));
-    assertNull(record.getField("code2"));
-  }
-
-  // --- backward compat: empty skipColumns behaves as before ---
-
-  @Test
-  public void testEmptySkipColumnsBackwardCompat() {
-    final SObject record = new SObject();
-    final Column column = new Column(0, "Name", Types.STRING);
-    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
-
-    doReturn(false).when(pageReader).isNull(column);
-    doReturn("John").when(pageReader).getString(column);
-
-    visitor.stringColumn(column);
-    assertEquals("John", record.getField("Name"));
-  }
-
-  @Test
-  public void testEmptySkipColumnsNullAddsToFieldsToNull() {
+  public void testNullColumnAddsToFieldsToNull() {
     final SObject record = new SObject();
     final Column column = new Column(0, "Name", Types.STRING);
     final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
@@ -258,5 +94,68 @@ public class TestSForceColumnVisitor {
 
     visitor.stringColumn(column);
     assertArrayEquals(new String[] {"Name"}, visitor.getFieldsToNull());
+  }
+
+  @Test
+  public void testNullLongColumnAddsToFieldsToNull() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "Amount", Types.LONG);
+    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
+
+    doReturn(true).when(pageReader).isNull(column);
+
+    visitor.longColumn(column);
+    assertArrayEquals(new String[] {"Amount"}, visitor.getFieldsToNull());
+  }
+
+  // --- Null handling: ignore_nulls=true ---
+
+  @Test
+  public void testNullColumnIgnoredWhenIgnoreNullsTrue() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "Name", Types.STRING);
+    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, true);
+
+    doReturn(true).when(pageReader).isNull(column);
+
+    visitor.stringColumn(column);
+    assertArrayEquals(new String[0], visitor.getFieldsToNull());
+  }
+
+  // --- Multiple columns ---
+
+  @Test
+  public void testMultipleColumnsProcessed() {
+    final SObject record = new SObject();
+    final Column col1 = new Column(0, "FirstName", Types.STRING);
+    final Column col2 = new Column(1, "LastName", Types.STRING);
+    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
+
+    doReturn(false).when(pageReader).isNull(col1);
+    doReturn("John").when(pageReader).getString(col1);
+    doReturn(false).when(pageReader).isNull(col2);
+    doReturn("Doe").when(pageReader).getString(col2);
+
+    visitor.stringColumn(col1);
+    visitor.stringColumn(col2);
+    assertEquals("John", record.getField("FirstName"));
+    assertEquals("Doe", record.getField("LastName"));
+  }
+
+  @Test
+  public void testMixedNullAndNonNullColumns() {
+    final SObject record = new SObject();
+    final Column col1 = new Column(0, "Name", Types.STRING);
+    final Column col2 = new Column(1, "Email", Types.STRING);
+    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
+
+    doReturn(false).when(pageReader).isNull(col1);
+    doReturn("John").when(pageReader).getString(col1);
+    doReturn(true).when(pageReader).isNull(col2);
+
+    visitor.stringColumn(col1);
+    visitor.stringColumn(col2);
+    assertEquals("John", record.getField("Name"));
+    assertArrayEquals(new String[] {"Email"}, visitor.getFieldsToNull());
   }
 }

--- a/src/test/java/org/embulk/output/sf_bulk_api/TestSForceColumnVisitor.java
+++ b/src/test/java/org/embulk/output/sf_bulk_api/TestSForceColumnVisitor.java
@@ -1,10 +1,16 @@
 package org.embulk.output.sf_bulk_api;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
 import com.sforce.soap.partner.sobject.SObject;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.type.Types;
@@ -12,6 +18,8 @@ import org.junit.Test;
 
 public class TestSForceColumnVisitor {
   private final PageReader pageReader = mock(PageReader.class);
+
+  // --- Existing basic type tests ---
 
   @Test
   public void testLongColumnNotNull() {
@@ -39,7 +47,7 @@ public class TestSForceColumnVisitor {
     assertEquals(1.1, record.getField("test"));
   }
 
-  @SuppressWarnings("deprecation") // For the use of org.embulk.spi.time.Timestamp.
+  @SuppressWarnings("deprecation")
   @Test
   public void testTimestampColumnNotNull() {
     final SObject record = new SObject();
@@ -51,5 +59,204 @@ public class TestSForceColumnVisitor {
 
     visitor.timestampColumn(column);
     assertEquals(100, ((Calendar) record.getField("test")).getTimeInMillis());
+  }
+
+  // --- skipColumns: string ---
+
+  @Test
+  public void testSkipColumnString() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "account_code", Types.STRING);
+    Set<String> skipColumns = new HashSet<>(Collections.singletonList("account_code"));
+    final SForceColumnVisitor visitor =
+        new SForceColumnVisitor(record, pageReader, false, skipColumns);
+
+    doReturn(false).when(pageReader).isNull(column);
+    doReturn("COMP-001").when(pageReader).getString(column);
+
+    visitor.stringColumn(column);
+    assertNull(record.getField("account_code"));
+  }
+
+  // --- skipColumns: all other types ---
+
+  @Test
+  public void testSkipColumnBoolean() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "skip_bool", Types.BOOLEAN);
+    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_bool"));
+    final SForceColumnVisitor visitor =
+        new SForceColumnVisitor(record, pageReader, false, skipColumns);
+
+    doReturn(false).when(pageReader).isNull(column);
+    doReturn(true).when(pageReader).getBoolean(column);
+
+    visitor.booleanColumn(column);
+    assertNull(record.getField("skip_bool"));
+  }
+
+  @Test
+  public void testSkipColumnLong() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "skip_long", Types.LONG);
+    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_long"));
+    final SForceColumnVisitor visitor =
+        new SForceColumnVisitor(record, pageReader, false, skipColumns);
+
+    doReturn(false).when(pageReader).isNull(column);
+    doReturn(42L).when(pageReader).getLong(column);
+
+    visitor.longColumn(column);
+    assertNull(record.getField("skip_long"));
+  }
+
+  @Test
+  public void testSkipColumnDouble() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "skip_double", Types.DOUBLE);
+    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_double"));
+    final SForceColumnVisitor visitor =
+        new SForceColumnVisitor(record, pageReader, false, skipColumns);
+
+    doReturn(false).when(pageReader).isNull(column);
+    doReturn(3.14).when(pageReader).getDouble(column);
+
+    visitor.doubleColumn(column);
+    assertNull(record.getField("skip_double"));
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void testSkipColumnTimestamp() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "skip_ts", Types.TIMESTAMP);
+    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_ts"));
+    final SForceColumnVisitor visitor =
+        new SForceColumnVisitor(record, pageReader, false, skipColumns);
+
+    doReturn(false).when(pageReader).isNull(column);
+    doReturn(org.embulk.spi.time.Timestamp.ofEpochMilli(100)).when(pageReader).getTimestamp(column);
+
+    visitor.timestampColumn(column);
+    assertNull(record.getField("skip_ts"));
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void testSkipColumnJson() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "skip_json", Types.JSON);
+    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_json"));
+    final SForceColumnVisitor visitor =
+        new SForceColumnVisitor(record, pageReader, false, skipColumns);
+
+    doReturn(false).when(pageReader).isNull(column);
+
+    visitor.jsonColumn(column);
+    assertNull(record.getField("skip_json"));
+  }
+
+  // --- skipColumns: null handling ---
+
+  @Test
+  public void testSkipColumnNullNotAddedToFieldsToNull() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "account_code", Types.STRING);
+    Set<String> skipColumns = new HashSet<>(Collections.singletonList("account_code"));
+    final SForceColumnVisitor visitor =
+        new SForceColumnVisitor(record, pageReader, false, skipColumns);
+
+    doReturn(true).when(pageReader).isNull(column);
+
+    visitor.stringColumn(column);
+    assertArrayEquals(new String[0], visitor.getFieldsToNull());
+  }
+
+  @Test
+  public void testSkipColumnNullLongNotAddedToFieldsToNull() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "skip_long", Types.LONG);
+    Set<String> skipColumns = new HashSet<>(Collections.singletonList("skip_long"));
+    final SForceColumnVisitor visitor =
+        new SForceColumnVisitor(record, pageReader, false, skipColumns);
+
+    doReturn(true).when(pageReader).isNull(column);
+
+    visitor.longColumn(column);
+    assertArrayEquals(new String[0], visitor.getFieldsToNull());
+  }
+
+  // --- skipColumns: mixed with non-skip columns ---
+
+  @Test
+  public void testNonSkipColumnStillProcessed() {
+    final SObject record = new SObject();
+    final Column normalCol = new Column(0, "FirstName", Types.STRING);
+    final Column skipCol = new Column(1, "account_code", Types.STRING);
+    Set<String> skipColumns = new HashSet<>(Collections.singletonList("account_code"));
+    final SForceColumnVisitor visitor =
+        new SForceColumnVisitor(record, pageReader, false, skipColumns);
+
+    doReturn(false).when(pageReader).isNull(normalCol);
+    doReturn("John").when(pageReader).getString(normalCol);
+    doReturn(false).when(pageReader).isNull(skipCol);
+    doReturn("COMP-001").when(pageReader).getString(skipCol);
+
+    visitor.stringColumn(normalCol);
+    visitor.stringColumn(skipCol);
+    assertEquals("John", record.getField("FirstName"));
+    assertNull(record.getField("account_code"));
+  }
+
+  @Test
+  public void testMultipleSkipColumns() {
+    final SObject record = new SObject();
+    final Column col1 = new Column(0, "Name", Types.STRING);
+    final Column col2 = new Column(1, "code1", Types.STRING);
+    final Column col3 = new Column(2, "code2", Types.STRING);
+    Set<String> skipColumns = new HashSet<>(Arrays.asList("code1", "code2"));
+    final SForceColumnVisitor visitor =
+        new SForceColumnVisitor(record, pageReader, false, skipColumns);
+
+    doReturn(false).when(pageReader).isNull(col1);
+    doReturn("John").when(pageReader).getString(col1);
+    doReturn(false).when(pageReader).isNull(col2);
+    doReturn("A").when(pageReader).getString(col2);
+    doReturn(false).when(pageReader).isNull(col3);
+    doReturn("B").when(pageReader).getString(col3);
+
+    visitor.stringColumn(col1);
+    visitor.stringColumn(col2);
+    visitor.stringColumn(col3);
+    assertEquals("John", record.getField("Name"));
+    assertNull(record.getField("code1"));
+    assertNull(record.getField("code2"));
+  }
+
+  // --- backward compat: empty skipColumns behaves as before ---
+
+  @Test
+  public void testEmptySkipColumnsBackwardCompat() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "Name", Types.STRING);
+    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
+
+    doReturn(false).when(pageReader).isNull(column);
+    doReturn("John").when(pageReader).getString(column);
+
+    visitor.stringColumn(column);
+    assertEquals("John", record.getField("Name"));
+  }
+
+  @Test
+  public void testEmptySkipColumnsNullAddsToFieldsToNull() {
+    final SObject record = new SObject();
+    final Column column = new Column(0, "Name", Types.STRING);
+    final SForceColumnVisitor visitor = new SForceColumnVisitor(record, pageReader, false);
+
+    doReturn(true).when(pageReader).isNull(column);
+
+    visitor.stringColumn(column);
+    assertArrayEquals(new String[] {"Name"}, visitor.getFieldsToNull());
   }
 }

--- a/src/test/java/org/embulk/output/sf_bulk_api/TestSfBulkApiFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sf_bulk_api/TestSfBulkApiFileOutputPlugin.java
@@ -4,13 +4,17 @@ import static org.embulk.output.sf_bulk_api.Util.mockActionResponse;
 import static org.embulk.output.sf_bulk_api.Util.mockResponse;
 import static org.embulk.output.sf_bulk_api.Util.newDefaultConfigSource;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -58,6 +62,8 @@ public class TestSfBulkApiFileOutputPlugin {
           .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
           .registerPlugin(OutputPlugin.class, "sf_bulk_api", SfBulkApiOutputPlugin.class)
           .build();
+
+  // ========== Existing basic tests ==========
 
   @Test
   public void testInsert() throws IOException, InterruptedException {
@@ -166,6 +172,587 @@ public class TestSfBulkApiFileOutputPlugin {
         });
   }
 
+  @Test
+  public void testBatchSizeZero() {
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer).set("action_type", "insert").set("batch_size", 0);
+    PartialExecutionException e =
+        assertThrows(
+            PartialExecutionException.class,
+            () ->
+                embulk.runOutput(
+                    config, Util.createInputFile(testFolder, "id:string", "id0").toPath()));
+    assertEquals(ConfigException.class, e.getCause().getClass());
+  }
+
+  @Test
+  public void testBatchSizeOver200() {
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer).set("action_type", "insert").set("batch_size", 201);
+    PartialExecutionException e =
+        assertThrows(
+            PartialExecutionException.class,
+            () ->
+                embulk.runOutput(
+                    config, Util.createInputFile(testFolder, "id:string", "id0").toPath()));
+    assertEquals(ConfigException.class, e.getCause().getClass());
+  }
+
+  @Test
+  public void testBatchSizeCustom() throws IOException, InterruptedException {
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer).set("action_type", "insert").set("batch_size", 1);
+    PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, PluginTask.class);
+
+    // 2 records with batch_size=1 → 2 API calls
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse(task.getActionType(), 1));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse(task.getActionType(), 1));
+    File in = Util.createInputFile(testFolder, "id:string", "id0", "id1");
+    embulk.runOutput(config, in.toPath());
+
+    // login + 2 action calls; no logout
+    assertEquals(3, mockWebServer.getRequestCount());
+  }
+
+  // ========== Association: validation tests ==========
+
+  @Test
+  public void testAssociationSourceColumnNotInSchema() {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "AccountId");
+    assoc.put("referenced_object", "Account");
+    assoc.put("unique_key", "External_Id__c");
+    assoc.put("source_column", "nonexistent_column");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("associations", Arrays.asList(assoc));
+    PartialExecutionException e =
+        assertThrows(
+            PartialExecutionException.class,
+            () ->
+                embulk.runOutput(
+                    config, Util.createInputFile(testFolder, "id:string", "id0").toPath()));
+    assertEquals(ConfigException.class, e.getCause().getClass());
+  }
+
+  @Test
+  public void testAssociationDuplicateReferenceField() {
+    Map<String, String> assoc1 = new HashMap<>();
+    assoc1.put("reference_field", "AccountId");
+    assoc1.put("referenced_object", "Account");
+    assoc1.put("unique_key", "External_Id__c");
+    assoc1.put("source_column", "code1");
+    Map<String, String> assoc2 = new HashMap<>();
+    assoc2.put("reference_field", "AccountId");
+    assoc2.put("referenced_object", "Account");
+    assoc2.put("unique_key", "External_Id__c");
+    assoc2.put("source_column", "code2");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("associations", Arrays.asList(assoc1, assoc2));
+    PartialExecutionException e =
+        assertThrows(
+            PartialExecutionException.class,
+            () ->
+                embulk.runOutput(
+                    config,
+                    Util.createInputFile(
+                            testFolder, "id:string,code1:string,code2:string", "id0,c1,c2")
+                        .toPath()));
+    assertEquals(ConfigException.class, e.getCause().getClass());
+  }
+
+  // ========== Association: empty associations (backward compatibility) ==========
+
+  @Test
+  public void testEmptyAssociationsBackwardCompat() throws IOException, InterruptedException {
+    // Explicitly set empty associations — should behave identically to no associations
+    testSuccessRun(
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("associations", Arrays.asList()),
+        new Column[] {
+          new Column(0, "id", Types.STRING), new Column(1, "test", Types.STRING),
+        },
+        new String[] {"id0,test0"},
+        new String[] {"string", "string"},
+        new String[] {"id0,test0"});
+  }
+
+  // ========== Association: single association insert ==========
+
+  @Test
+  public void testAssociationInsertNestedSObject() throws IOException, InterruptedException {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "AccountId");
+    assoc.put("referenced_object", "Account");
+    assoc.put("unique_key", "External_Id__c");
+    assoc.put("source_column", "account_code");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("associations", Arrays.asList(assoc));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    File in =
+        Util.createInputFile(testFolder, "Name:string,account_code:string", "John Doe,COMP-001");
+    embulk.runOutput(config, in.toPath());
+
+    assertEquals(2, mockWebServer.getRequestCount());
+    mockWebServer.takeRequest(); // skip login
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // Verify nested SObject is present with correct structure
+    assertTrue(body.contains("<sobj:Account>"));
+    assertTrue(body.contains("<sobj:type xsi:type=\"xsd:string\">Account</sobj:type>"));
+    assertTrue(
+        body.contains(
+            "<sobj:External_Id__c xsi:type=\"xsd:string\">COMP-001</sobj:External_Id__c>"));
+    assertTrue(body.contains("</sobj:Account>"));
+
+    // Verify source_column value is NOT set as a direct field
+    assertFalse(body.contains("<sobj:account_code"));
+
+    // Verify normal fields are still present
+    assertTrue(body.contains("<sobj:Name xsi:type=\"xsd:string\">John Doe</sobj:Name>"));
+  }
+
+  // ========== Association: multiple associations ==========
+
+  @Test
+  public void testAssociationMultipleNestedSObjects() throws IOException, InterruptedException {
+    Map<String, String> assoc1 = new HashMap<>();
+    assoc1.put("reference_field", "AccountId");
+    assoc1.put("referenced_object", "Account");
+    assoc1.put("unique_key", "External_Id__c");
+    assoc1.put("source_column", "account_code");
+    Map<String, String> assoc2 = new HashMap<>();
+    assoc2.put("reference_field", "ReportsToId");
+    assoc2.put("referenced_object", "Contact");
+    assoc2.put("unique_key", "Email");
+    assoc2.put("source_column", "manager_email");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("associations", Arrays.asList(assoc1, assoc2));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    File in =
+        Util.createInputFile(
+            testFolder,
+            "Name:string,account_code:string,manager_email:string",
+            "John Doe,COMP-001,boss@example.com");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // First association: Account
+    assertTrue(body.contains("<sobj:Account>"));
+    assertTrue(
+        body.contains(
+            "<sobj:External_Id__c xsi:type=\"xsd:string\">COMP-001</sobj:External_Id__c>"));
+
+    // Second association: ReportsTo
+    assertTrue(body.contains("<sobj:ReportsTo>"));
+    assertTrue(body.contains("<sobj:type xsi:type=\"xsd:string\">Contact</sobj:type>"));
+    assertTrue(body.contains("<sobj:Email xsi:type=\"xsd:string\">boss@example.com</sobj:Email>"));
+
+    // Source columns are NOT direct fields
+    assertFalse(body.contains("<sobj:account_code"));
+    assertFalse(body.contains("<sobj:manager_email"));
+  }
+
+  // ========== Association: null handling ==========
+
+  @Test
+  public void testAssociationNullSourceColumnIgnoreNullsFalse()
+      throws IOException, InterruptedException {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "AccountId");
+    assoc.put("referenced_object", "Account");
+    assoc.put("unique_key", "External_Id__c");
+    assoc.put("source_column", "account_code");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("ignore_nulls", false)
+            .set("associations", Arrays.asList(assoc));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    File in = Util.createInputFile(testFolder, "Name:string,account_code:string", "John Doe,");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // No nested SObject should be present
+    assertFalse(body.contains("<sobj:Account>"));
+
+    // reference_field (AccountId) should be in fieldsToNull
+    assertTrue(
+        body.contains("<sobj:fieldsToNull xsi:type=\"xsd:string\">AccountId</sobj:fieldsToNull>"));
+  }
+
+  @Test
+  public void testAssociationNullSourceColumnIgnoreNullsTrue()
+      throws IOException, InterruptedException {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "AccountId");
+    assoc.put("referenced_object", "Account");
+    assoc.put("unique_key", "External_Id__c");
+    assoc.put("source_column", "account_code");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("ignore_nulls", true)
+            .set("associations", Arrays.asList(assoc));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    File in = Util.createInputFile(testFolder, "Name:string,account_code:string", "John Doe,");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // No nested SObject
+    assertFalse(body.contains("<sobj:Account>"));
+    // No fieldsToNull for AccountId (ignore_nulls=true → preserve existing reference)
+    assertFalse(body.contains("AccountId"));
+    // No fieldsToNull at all (ignore_nulls=true)
+    assertFalse(body.contains("fieldsToNull"));
+  }
+
+  // ========== Association: mixed null and non-null in multiple associations ==========
+
+  @Test
+  public void testAssociationMixedNullAndNonNull() throws IOException, InterruptedException {
+    Map<String, String> assoc1 = new HashMap<>();
+    assoc1.put("reference_field", "AccountId");
+    assoc1.put("referenced_object", "Account");
+    assoc1.put("unique_key", "External_Id__c");
+    assoc1.put("source_column", "account_code");
+    Map<String, String> assoc2 = new HashMap<>();
+    assoc2.put("reference_field", "ReportsToId");
+    assoc2.put("referenced_object", "Contact");
+    assoc2.put("unique_key", "Email");
+    assoc2.put("source_column", "manager_email");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("ignore_nulls", false)
+            .set("associations", Arrays.asList(assoc1, assoc2));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    // account_code has value, manager_email is null
+    File in =
+        Util.createInputFile(
+            testFolder,
+            "Name:string,account_code:string,manager_email:string",
+            "John Doe,COMP-001,");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // First association (non-null) → nested SObject
+    assertTrue(body.contains("<sobj:Account>"));
+    assertTrue(
+        body.contains(
+            "<sobj:External_Id__c xsi:type=\"xsd:string\">COMP-001</sobj:External_Id__c>"));
+
+    // Second association (null) → fieldsToNull with ReportsToId
+    assertFalse(body.contains("<sobj:ReportsTo>"));
+    assertTrue(
+        body.contains(
+            "<sobj:fieldsToNull xsi:type=\"xsd:string\">ReportsToId</sobj:fieldsToNull>"));
+  }
+
+  // ========== Association: with different action types ==========
+
+  @Test
+  public void testAssociationWithUpsert() throws IOException, InterruptedException {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "AccountId");
+    assoc.put("referenced_object", "Account");
+    assoc.put("unique_key", "External_Id__c");
+    assoc.put("source_column", "account_code");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "upsert")
+            .set("associations", Arrays.asList(assoc));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("upsert", 1));
+    File in =
+        Util.createInputFile(testFolder, "Name:string,account_code:string", "John Doe,COMP-001");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // Verify it's an upsert request
+    assertTrue(body.contains("m:upsert"));
+    assertTrue(body.contains("<m:externalIDFieldName>key</m:externalIDFieldName>"));
+
+    // Nested SObject is present
+    assertTrue(body.contains("<sobj:Account>"));
+    assertTrue(
+        body.contains(
+            "<sobj:External_Id__c xsi:type=\"xsd:string\">COMP-001</sobj:External_Id__c>"));
+  }
+
+  @Test
+  public void testAssociationWithUpdate() throws IOException, InterruptedException {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "AccountId");
+    assoc.put("referenced_object", "Account");
+    assoc.put("unique_key", "External_Id__c");
+    assoc.put("source_column", "account_code");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "update")
+            .set("associations", Arrays.asList(assoc));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("update", 1));
+    File in =
+        Util.createInputFile(testFolder, "Name:string,account_code:string", "John Doe,COMP-001");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // Verify it's an update request
+    assertTrue(body.contains("m:update"));
+
+    // Nested SObject is present
+    assertTrue(body.contains("<sobj:Account>"));
+  }
+
+  // ========== Association: custom field (relationship_name derivation __c → __r) ==========
+
+  @Test
+  public void testAssociationCustomField() throws IOException, InterruptedException {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "Company__c");
+    assoc.put("referenced_object", "TestCompany__c");
+    assoc.put("unique_key", "Company_Code__c");
+    assoc.put("source_column", "company_code");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("associations", Arrays.asList(assoc));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    File in =
+        Util.createInputFile(testFolder, "Name:string,company_code:string", "John Doe,COMP-001");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // Company__c → Company__r (relationship_name)
+    assertTrue(body.contains("<sobj:Company__r>"));
+    assertTrue(body.contains("<sobj:type xsi:type=\"xsd:string\">TestCompany__c</sobj:type>"));
+    assertTrue(
+        body.contains(
+            "<sobj:Company_Code__c xsi:type=\"xsd:string\">COMP-001</sobj:Company_Code__c>"));
+    assertTrue(body.contains("</sobj:Company__r>"));
+  }
+
+  // ========== Association: multiple records in single batch ==========
+
+  @Test
+  public void testAssociationMultipleRecords() throws IOException, InterruptedException {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "AccountId");
+    assoc.put("referenced_object", "Account");
+    assoc.put("unique_key", "External_Id__c");
+    assoc.put("source_column", "account_code");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("associations", Arrays.asList(assoc));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 3));
+    File in =
+        Util.createInputFile(
+            testFolder,
+            "Name:string,account_code:string",
+            "Alice,COMP-001",
+            "Bob,COMP-002",
+            "Charlie,COMP-001");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // 3 sObjects in the request
+    assertEquals(3, countOccurrences(body, "<m:sObjects>"));
+
+    // All have nested Account
+    assertEquals(3, countOccurrences(body, "<sobj:Account>"));
+
+    // Verify individual values
+    assertTrue(body.contains("COMP-001"));
+    assertTrue(body.contains("COMP-002"));
+  }
+
+  // ========== Association: non-string source_column type (long) ==========
+
+  @Test
+  public void testAssociationSourceColumnLongType() throws IOException, InterruptedException {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "AccountId");
+    assoc.put("referenced_object", "Account");
+    assoc.put("unique_key", "External_Number__c");
+    assoc.put("source_column", "account_number");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("associations", Arrays.asList(assoc));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    File in = Util.createInputFile(testFolder, "Name:string,account_number:long", "John Doe,12345");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // Long value is converted to string for the nested SObject
+    assertTrue(body.contains("<sobj:Account>"));
+    assertTrue(
+        body.contains(
+            "<sobj:External_Number__c xsi:type=\"xsd:string\">12345</sobj:External_Number__c>"));
+
+    // source_column is NOT set as a direct field
+    assertFalse(body.contains("<sobj:account_number"));
+  }
+
+  // ========== Association: same source_column used by multiple associations ==========
+
+  @Test
+  public void testAssociationSameSourceColumnMultipleAssociations()
+      throws IOException, InterruptedException {
+    // Same source_column "code" is used by two different associations
+    Map<String, String> assoc1 = new HashMap<>();
+    assoc1.put("reference_field", "AccountId");
+    assoc1.put("referenced_object", "Account");
+    assoc1.put("unique_key", "External_Id__c");
+    assoc1.put("source_column", "code");
+    Map<String, String> assoc2 = new HashMap<>();
+    assoc2.put("reference_field", "My_Custom__c");
+    assoc2.put("referenced_object", "CustomObj__c");
+    assoc2.put("unique_key", "Code__c");
+    assoc2.put("source_column", "code");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("associations", Arrays.asList(assoc1, assoc2));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    File in = Util.createInputFile(testFolder, "Name:string,code:string", "John Doe,SHARED-001");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // Both associations create nested SObjects from the same source value
+    assertTrue(body.contains("<sobj:Account>"));
+    assertTrue(body.contains("<sobj:My_Custom__r>"));
+    // Both use the same value
+    assertEquals(2, countOccurrences(body, "SHARED-001"));
+  }
+
+  // ========== Association: null handling with mixed normal null fields ==========
+
+  @Test
+  public void testAssociationNullWithOtherNullFieldsIgnoreNullsFalse()
+      throws IOException, InterruptedException {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "AccountId");
+    assoc.put("referenced_object", "Account");
+    assoc.put("unique_key", "External_Id__c");
+    assoc.put("source_column", "account_code");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("ignore_nulls", false)
+            .set("associations", Arrays.asList(assoc));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    // Both Name and account_code are null
+    File in = Util.createInputFile(testFolder, "Name:string,account_code:string", ",");
+    embulk.runOutput(config, in.toPath());
+
+    mockWebServer.takeRequest();
+    String body = Util.toStringFromGZip(mockWebServer.takeRequest());
+
+    // Name should be in fieldsToNull (normal null field)
+    assertTrue(
+        body.contains("<sobj:fieldsToNull xsi:type=\"xsd:string\">Name</sobj:fieldsToNull>"));
+    // AccountId should also be in fieldsToNull (association null)
+    assertTrue(
+        body.contains("<sobj:fieldsToNull xsi:type=\"xsd:string\">AccountId</sobj:fieldsToNull>"));
+    // No nested SObject
+    assertFalse(body.contains("<sobj:Account>"));
+  }
+
+  // ========== Association: records across multiple batches ==========
+
+  @Test
+  public void testAssociationWithBatchSize() throws IOException, InterruptedException {
+    Map<String, String> assoc = new HashMap<>();
+    assoc.put("reference_field", "AccountId");
+    assoc.put("referenced_object", "Account");
+    assoc.put("unique_key", "External_Id__c");
+    assoc.put("source_column", "account_code");
+    ConfigSource config =
+        newDefaultConfigSource(mockWebServer)
+            .set("action_type", "insert")
+            .set("batch_size", 1)
+            .set("associations", Arrays.asList(assoc));
+
+    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    mockWebServer.enqueue(Util.mockActionSuccessResponse("insert", 1));
+    File in =
+        Util.createInputFile(
+            testFolder, "Name:string,account_code:string", "Alice,COMP-001", "Bob,COMP-002");
+    embulk.runOutput(config, in.toPath());
+
+    // login + 2 batches
+    assertEquals(3, mockWebServer.getRequestCount());
+
+    mockWebServer.takeRequest(); // login
+
+    String body1 = Util.toStringFromGZip(mockWebServer.takeRequest());
+    assertTrue(body1.contains("Alice"));
+    assertTrue(body1.contains("COMP-001"));
+    assertTrue(body1.contains("<sobj:Account>"));
+
+    String body2 = Util.toStringFromGZip(mockWebServer.takeRequest());
+    assertTrue(body2.contains("Bob"));
+    assertTrue(body2.contains("COMP-002"));
+    assertTrue(body2.contains("<sobj:Account>"));
+  }
+
+  // ========== Helper methods ==========
+
   private void testSuccessRun(String actionType) throws IOException, InterruptedException {
     testSuccessRun(
         newDefaultConfigSource(mockWebServer).set("action_type", actionType),
@@ -225,52 +812,19 @@ public class TestSfBulkApiFileOutputPlugin {
     assertEquals(expectedBody, Util.toStringFromGZip(mockWebServer.takeRequest()));
   }
 
-  @Test
-  public void testBatchSizeZero() {
-    ConfigSource config =
-        newDefaultConfigSource(mockWebServer).set("action_type", "insert").set("batch_size", 0);
-    PartialExecutionException e =
-        assertThrows(
-            PartialExecutionException.class,
-            () ->
-                embulk.runOutput(
-                    config, Util.createInputFile(testFolder, "id:string", "id0").toPath()));
-    assertEquals(ConfigException.class, e.getCause().getClass());
-  }
-
-  @Test
-  public void testBatchSizeOver200() {
-    ConfigSource config =
-        newDefaultConfigSource(mockWebServer).set("action_type", "insert").set("batch_size", 201);
-    PartialExecutionException e =
-        assertThrows(
-            PartialExecutionException.class,
-            () ->
-                embulk.runOutput(
-                    config, Util.createInputFile(testFolder, "id:string", "id0").toPath()));
-    assertEquals(ConfigException.class, e.getCause().getClass());
-  }
-
-  @Test
-  public void testBatchSizeCustom() throws IOException, InterruptedException {
-    ConfigSource config =
-        newDefaultConfigSource(mockWebServer).set("action_type", "insert").set("batch_size", 1);
-    PluginTask task = CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, PluginTask.class);
-
-    // 2 records with batch_size=1 → 2 API calls
-    mockWebServer.enqueue(mockResponse("loginResponseBody.xml"));
-    mockWebServer.enqueue(Util.mockActionSuccessResponse(task.getActionType(), 1));
-    mockWebServer.enqueue(Util.mockActionSuccessResponse(task.getActionType(), 1));
-    File in = Util.createInputFile(testFolder, "id:string", "id0", "id1");
-    embulk.runOutput(config, in.toPath());
-
-    // login + 2 action calls; no logout
-    assertEquals(3, mockWebServer.getRequestCount());
-  }
-
   private static String[] concat(String[] src, String elem) {
     List<String> list = new ArrayList<>(Arrays.asList(src));
     list.add(elem);
     return list.toArray(new String[0]);
+  }
+
+  private static int countOccurrences(String str, String sub) {
+    int count = 0;
+    int idx = 0;
+    while ((idx = str.indexOf(sub, idx)) != -1) {
+      count++;
+      idx += sub.length();
+    }
+    return count;
   }
 }


### PR DESCRIPTION
## Summary

Support setting Salesforce reference (lookup/master-detail) fields via external IDs using the Partner SOAP API's nested SObject mechanism. Salesforce resolves the external ID to the record ID server-side within the same API call — no additional API calls are needed.

## Config example

```yaml
associations:
  - reference_field: AccountId
    referenced_object: Account
    unique_key: External_Id__c
    source_column: account_code
```

## Behavior

### Basic: External ID reference resolution

The plugin reads the `source_column` value from input data, builds a nested SObject, and lets Salesforce resolve the reference server-side.

| Input | Generated SObject |
|---|---|
| `account_code = "COMP-001"` | `record.Account.External_Id__c = "COMP-001"` (nested SObject) |

`relationship_name` is derived automatically from `reference_field`:
- Standard fields: `AccountId` → `Account` (strip trailing `Id`)
- Custom fields: `Company__c` → `Company__r` (replace `__c` with `__r`)

### Null handling

When `source_column` is null, behavior depends on the `ignore_nulls` setting.

| ignore_nulls | Behavior when source_column is null |
|---|---|
| `true` (default) | Do nothing. The existing reference is preserved as-is. |
| `false` | Add `reference_field` (e.g. `AccountId`) to `fieldsToNull`, clearing the existing reference. |

Records with null and non-null values can coexist in the same batch — each record is handled independently.

### Multiple associations

Multiple associations can be specified per record. Each produces an independent nested SObject.

```yaml
associations:
  - reference_field: AccountId          # resolved via Account.External_Id__c
    referenced_object: Account
    unique_key: External_Id__c
    source_column: account_code
  - reference_field: ReportsToId        # resolved via Contact.Email
    referenced_object: Contact
    unique_key: Email
    source_column: manager_email
```

The same `source_column` can be shared across multiple associations (e.g. using one input column to set both `Company__c` and `CompanyLookup__c`).

### Polymorphic references

For polymorphic reference fields like `OwnerId` (User/Group), `referenced_object` specifies which object type to resolve against.

```yaml
associations:
  - reference_field: OwnerId
    referenced_object: User           # specify User or Group
    unique_key: Username
    source_column: owner_username
```

Normal and polymorphic associations can be used together on the same record.

### Error handling

When no record matches the `source_column` value on the Salesforce side, Salesforce returns an `INVALID_FIELD` error.

| throw_if_failed | Behavior |
|---|---|
| `true` (default) | Embulk exits with error (`DataException`) |
| `false` | Error is logged, job completes normally |

### Backward compatibility

`associations` defaults to `[]` (empty list). When not specified, existing behavior is completely unchanged.

### source_column skipping

`source_column` columns are skipped from direct SObject field assignment and excluded from `fieldsToNull`. This is necessary because the association processing needs to read these column values from the input, so they must be present in the output schema. However, the output plugin's column visitor normally tries to set every schema column as an SObject field. If a `source_column` (e.g. `account_code`) does not exist as a field on the target Salesforce object, setting it directly would cause an `INVALID_FIELD` error. The skip mechanism prevents this while still allowing the association logic to read the value and build the nested SObject.

Null handling for skipped columns is done exclusively in the association processing logic (see "Null handling" above).

---

## 概要

Salesforce Partner SOAP APIのネストSObject方式を使い、外部IDによる参照関係フィールド（Lookup/Master-Detail）の設定をサポートする。`associations` configで `reference_field`, `referenced_object`, `unique_key`, `source_column` の4フィールドを指定し、Salesforceサーバー側でID解決を委ねる（追加APIコール不要）。

## 設定例

```yaml
associations:
  - reference_field: AccountId
    referenced_object: Account
    unique_key: External_Id__c
    source_column: account_code
```

## 挙動仕様

### 基本: 外部IDによる参照解決

入力データの `source_column` の値を使って、Salesforce側で参照先レコードを解決する。プラグインはネストSObjectを構築し、Salesforceサーバーが同一APIコール内でID解決を行う。

| 入力 | 生成されるSObject |
|---|---|
| `account_code = "COMP-001"` | `record.Account.External_Id__c = "COMP-001"` (ネストSObject) |

`reference_field` から `relationship_name` を自動導出する:
- 標準フィールド: `AccountId` → `Account`（末尾の `Id` を除去）
- カスタムフィールド: `Company__c` → `Company__r`（`__c` を `__r` に置換）

### null時の挙動

`source_column` の値がnullの場合、`ignore_nulls` 設定に応じて動作が変わる。

| ignore_nulls | source_columnがnull時の挙動 |
|---|---|
| `true`（デフォルト） | 何もしない。既存の参照関係がそのまま維持される |
| `false` | `reference_field`（例: `AccountId`）を `fieldsToNull` に追加し、既存の参照をクリアする |

同一バッチ内でnullと非nullのレコードが混在する場合も、レコードごとに正しく処理される。

### 複数association

1レコードに複数のassociationを指定可能。それぞれ独立にネストSObjectが生成される。

```yaml
associations:
  - reference_field: AccountId          # → Account.External_Id__c で解決
    referenced_object: Account
    unique_key: External_Id__c
    source_column: account_code
  - reference_field: ReportsToId        # → ReportsTo.Email で解決
    referenced_object: Contact
    unique_key: Email
    source_column: manager_email
```

同一の `source_column` を複数のassociationで共有することも可能（例: 同じ入力カラムで `Company__c` と `CompanyLookup__c` の両方を設定）。

### ポリモーフィック参照

`OwnerId`（User/Group）のようなポリモーフィック参照フィールドでは、`referenced_object` で対象オブジェクト型を明示する。

```yaml
associations:
  - reference_field: OwnerId
    referenced_object: User           # User と Group のどちらかを指定
    unique_key: Username
    source_column: owner_username
```

通常の参照とポリモーフィック参照を同一レコードで同時に使用可能。

### エラー時の挙動

`source_column` の値に一致するレコードがSalesforce側に存在しない場合、Salesforceが `INVALID_FIELD` エラーを返す。

| throw_if_failed | 挙動 |
|---|---|
| `true`（デフォルト） | Embulkがエラー終了（`DataException`） |
| `false` | エラーをログに記録してジョブは正常終了 |

### 後方互換性

`associations` のデフォルトは `[]`（空リスト）。設定しない場合、既存の動作に一切影響しない。

### source_column のスキップ

`source_column` で指定されたカラムは、SObjectへの直接フィールドセットおよび `fieldsToNull` からスキップされる。

これが必要な理由: association処理で `source_column` の値を読む必要があるため、出力スキーマにカラムが含まれている必要がある。しかし出力プラグインのvisitorはスキーマの全カラムをSObjectフィールドとしてセットしようとする。`source_column`（例: `account_code`）が転送先SFオブジェクトにフィールドとして存在しない場合、直接セットすると `INVALID_FIELD` エラーになる。スキップ機構により、visitorでの直接セットを防ぎつつ、association処理側で値を読んでネストSObjectを構築できるようにしている。

スキップされたカラムのnull処理はassociation処理側で行われる（上記「null時の挙動」参照）。

---

## Changes
- `AssociationConfig.java` — New: association config interface + `deriveRelationshipName()`
- `PluginTask.java` — Add `List<AssociationConfig> getAssociations()` (default `[]`, backward compatible)
- `SfBulkApiOutputPlugin.java` — Validation: `source_column` existence + `reference_field` uniqueness
- `SForceColumnVisitor.java` — Add `skipColumns` parameter, skip association source columns from SObject
- `SForceTransactionalPageOutput.java` — Nested SObject generation, null/fieldsToNull handling

## Test plan
- [x] `TestAssociationConfig` — `deriveRelationshipName` patterns (standard Id / custom __c / fallback)
- [x] `TestSForceColumnVisitor` — skipColumns coverage for all types, null behavior, backward compat
- [x] `TestSfBulkApiFileOutputPlugin` — SOAP XML integration tests (nested SObject, null handling, multiple associations, custom fields, batch splitting, validation errors)
- [x] Salesforce Sandbox E2E: 14 cases all passed (normal / null handling / errors / polymorphic / backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)